### PR TITLE
[feat] 인증 정보 반환 API 추가 및 보안 설정, 위키 중복 생성 로직 추가

### DIFF
--- a/src/main/java/kr/dgucaps/caps/domain/dto/MemberSummary.java
+++ b/src/main/java/kr/dgucaps/caps/domain/dto/MemberSummary.java
@@ -3,10 +3,10 @@ package kr.dgucaps.caps.domain.dto;
 import kr.dgucaps.caps.domain.member.entity.Member;
 
 public record MemberSummary(
-        Long id,
+        long id,
         String name,
         String profileImageUrl,
-        float grade
+        Float grade
 ) {
     public static MemberSummary from(Member member) {
         return new MemberSummary(

--- a/src/main/java/kr/dgucaps/caps/domain/member/controller/AuthApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/controller/AuthApi.java
@@ -9,9 +9,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import kr.dgucaps.caps.domain.member.dto.request.CompleteRegistrationRequest;
-import kr.dgucaps.caps.domain.member.dto.request.MemberTokenRequest;
+import kr.dgucaps.caps.domain.member.dto.response.AuthInfoResponse;
 import kr.dgucaps.caps.domain.member.dto.response.MemberInfoResponse;
-import kr.dgucaps.caps.domain.member.dto.response.MemberTokenResponse;
 import kr.dgucaps.caps.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -54,4 +53,16 @@ public interface AuthApi {
     })
     ResponseEntity<SuccessResponse<?>> reissueToken(@CookieValue(value = "refreshToken", required = false) String refreshToken,
                                                            HttpServletResponse response);
+
+    @Operation(
+            summary = "인증 정보 조회",
+            description = "현재 로그인한 사용자의 인증 정보 및 온보딩 완료 여부를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 정보 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AuthInfoResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 정보가 없음")
+    })
+    ResponseEntity<SuccessResponse<?>> getAuthInfo(@AuthenticationPrincipal Long memberId);
 }

--- a/src/main/java/kr/dgucaps/caps/domain/member/controller/AuthApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/controller/AuthApi.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import kr.dgucaps.caps.domain.member.dto.request.CompleteRegistrationRequest;
 import kr.dgucaps.caps.domain.member.dto.response.AuthInfoResponse;
 import kr.dgucaps.caps.domain.member.dto.response.MemberInfoResponse;
+import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,7 +29,7 @@ public interface AuthApi {
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = MemberInfoResponse.class))
     )
-    ResponseEntity<SuccessResponse<?>> completeRegistration(@AuthenticationPrincipal Long memberId,
+    ResponseEntity<SuccessResponse<?>> completeRegistration(@AuthenticationPrincipal(expression = "member") Member member,
                                                                    @RequestBody @Valid CompleteRegistrationRequest request);
 
     @Operation(
@@ -38,7 +39,7 @@ public interface AuthApi {
                     "클라이언트의 액세스, 리프레쉬 토큰을 삭제해야합니다."
     )
     @ApiResponse(responseCode = "204", description = "로그아웃 성공")
-    ResponseEntity<SuccessResponse<?>> logout(@AuthenticationPrincipal Long userId);
+    ResponseEntity<SuccessResponse<?>> logout(@AuthenticationPrincipal(expression = "member") Member member);
 
     @Operation(
             summary = "토큰 재발급",
@@ -64,5 +65,5 @@ public interface AuthApi {
                             schema = @Schema(implementation = AuthInfoResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 정보가 없음")
     })
-    ResponseEntity<SuccessResponse<?>> getAuthInfo(@AuthenticationPrincipal Long memberId);
+    ResponseEntity<SuccessResponse<?>> getAuthInfo(@AuthenticationPrincipal(expression = "member") Member member);
 }

--- a/src/main/java/kr/dgucaps/caps/domain/member/controller/AuthController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/controller/AuthController.java
@@ -40,4 +40,9 @@ public class AuthController implements AuthApi {
         tokenService.reissue(refreshToken, response);
         return SuccessResponse.noContent();
     }
+
+    @GetMapping("/me")
+    public ResponseEntity<SuccessResponse<?>> getAuthInfo(@AuthenticationPrincipal Long memberId) {
+        return SuccessResponse.ok(authService.getAuthInfo(memberId));
+    }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/member/controller/AuthController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/controller/AuthController.java
@@ -3,6 +3,7 @@ package kr.dgucaps.caps.domain.member.controller;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import kr.dgucaps.caps.domain.member.dto.request.CompleteRegistrationRequest;
+import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.domain.member.service.AuthService;
 import kr.dgucaps.caps.domain.member.service.TokenService;
 import kr.dgucaps.caps.global.common.SuccessResponse;
@@ -21,15 +22,15 @@ public class AuthController implements AuthApi {
 
     // 회원가입 후 추가 정보 입력
     @PatchMapping("/complete-registration")
-    public ResponseEntity<SuccessResponse<?>> completeRegistration(@AuthenticationPrincipal Long memberId,
+    public ResponseEntity<SuccessResponse<?>> completeRegistration(@AuthenticationPrincipal(expression = "member") Member member,
                                                                    @RequestBody @Valid CompleteRegistrationRequest request) {
-        return SuccessResponse.ok(authService.completeRegistration(memberId, request));
+        return SuccessResponse.ok(authService.completeRegistration(member, request));
     }
 
     // 로그아웃
     @PostMapping("/logout")
-    public ResponseEntity<SuccessResponse<?>> logout(@AuthenticationPrincipal Long userId) {
-        tokenService.logout(userId);
+    public ResponseEntity<SuccessResponse<?>> logout(@AuthenticationPrincipal(expression = "member") Member member) {
+        tokenService.logout(member);
         return SuccessResponse.noContent();
     }
 
@@ -42,7 +43,7 @@ public class AuthController implements AuthApi {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<SuccessResponse<?>> getAuthInfo(@AuthenticationPrincipal Long memberId) {
-        return SuccessResponse.ok(authService.getAuthInfo(memberId));
+    public ResponseEntity<SuccessResponse<?>> getAuthInfo(@AuthenticationPrincipal(expression = "member") Member member) {
+        return SuccessResponse.ok(authService.getAuthInfo(member));
     }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/member/controller/MemberApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/controller/MemberApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.dgucaps.caps.domain.member.dto.request.UpdateMemberRequest;
 import kr.dgucaps.caps.domain.member.dto.response.MemberInfoResponse;
+import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,7 +27,7 @@ public interface MemberApi {
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = MemberInfoResponse.class))
     )
-    ResponseEntity<SuccessResponse<?>> getMemberInfo(@AuthenticationPrincipal Long memberId);
+    ResponseEntity<SuccessResponse<?>> getMemberInfo(@AuthenticationPrincipal(expression = "member") Member member);
 
     @Operation(
             summary = "다른 회원 정보 조회",
@@ -49,6 +50,6 @@ public interface MemberApi {
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = MemberInfoResponse.class))
     )
-    ResponseEntity<SuccessResponse<?>> updateMember(@AuthenticationPrincipal Long memberId,
+    ResponseEntity<SuccessResponse<?>> updateMember(@AuthenticationPrincipal(expression = "member") Member member,
                                                     @Valid @RequestBody UpdateMemberRequest request);
 }

--- a/src/main/java/kr/dgucaps/caps/domain/member/controller/MemberController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package kr.dgucaps.caps.domain.member.controller;
 
 import jakarta.validation.Valid;
 import kr.dgucaps.caps.domain.member.dto.request.UpdateMemberRequest;
+import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.domain.member.service.MemberService;
 import kr.dgucaps.caps.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +18,8 @@ public class MemberController implements MemberApi {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public ResponseEntity<SuccessResponse<?>> getMemberInfo(@AuthenticationPrincipal Long memberId) {
-        return SuccessResponse.ok(memberService.getMemberInfo(memberId));
+    public ResponseEntity<SuccessResponse<?>> getMemberInfo(@AuthenticationPrincipal(expression = "member") Member member) {
+        return SuccessResponse.ok(memberService.getMemberInfo(member.getId()));
     }
 
     @GetMapping("/{memberId}")
@@ -27,9 +28,9 @@ public class MemberController implements MemberApi {
     }
 
     @PatchMapping("/me")
-    public ResponseEntity<SuccessResponse<?>> updateMember(@AuthenticationPrincipal Long memberId,
+    public ResponseEntity<SuccessResponse<?>> updateMember(@AuthenticationPrincipal(expression = "member") Member member,
                                                            @Valid @RequestBody UpdateMemberRequest request) {
-        return SuccessResponse.ok(memberService.updateMember(memberId, request));
+        return SuccessResponse.ok(memberService.updateMember(member, request));
     }
 
 //    @DeleteMapping("/user/{userId}")

--- a/src/main/java/kr/dgucaps/caps/domain/member/dto/response/AuthInfoResponse.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/dto/response/AuthInfoResponse.java
@@ -1,0 +1,18 @@
+package kr.dgucaps.caps.domain.member.dto.response;
+
+import kr.dgucaps.caps.domain.dto.MemberSummary;
+import kr.dgucaps.caps.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record AuthInfoResponse(
+        MemberSummary member,
+        boolean registrationComplete
+) {
+    public static AuthInfoResponse of(Member member) {
+        return AuthInfoResponse.builder()
+                .member(MemberSummary.from(member))
+                .registrationComplete(member.isRegistrationComplete())
+                .build();
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/member/entity/Role.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/entity/Role.java
@@ -18,6 +18,6 @@ public enum Role implements GrantedAuthority {
 
     @Override
     public String getAuthority() {
-        return name();
+        return "ROLE_" + this.name();
     }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/member/service/AuthService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/service/AuthService.java
@@ -1,6 +1,7 @@
 package kr.dgucaps.caps.domain.member.service;
 
 import kr.dgucaps.caps.domain.member.dto.request.CompleteRegistrationRequest;
+import kr.dgucaps.caps.domain.member.dto.response.AuthInfoResponse;
 import kr.dgucaps.caps.domain.member.dto.response.MemberInfoResponse;
 import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.domain.member.repository.MemberRepository;
@@ -24,5 +25,11 @@ public class AuthService {
         member.completeRegistration(request.studentNumber(), request.grade());
         Member savedMember = memberRepository.save(member);
         return MemberInfoResponse.from(savedMember);
+    }
+
+    public AuthInfoResponse getAuthInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        return AuthInfoResponse.of(member);
     }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/member/service/AuthService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/service/AuthService.java
@@ -5,8 +5,6 @@ import kr.dgucaps.caps.domain.member.dto.response.AuthInfoResponse;
 import kr.dgucaps.caps.domain.member.dto.response.MemberInfoResponse;
 import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.domain.member.repository.MemberRepository;
-import kr.dgucaps.caps.global.error.ErrorCode;
-import kr.dgucaps.caps.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,17 +17,13 @@ public class AuthService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public MemberInfoResponse completeRegistration(Long memberId, CompleteRegistrationRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    public MemberInfoResponse completeRegistration(Member member, CompleteRegistrationRequest request) {
         member.completeRegistration(request.studentNumber(), request.grade());
         Member savedMember = memberRepository.save(member);
         return MemberInfoResponse.from(savedMember);
     }
 
-    public AuthInfoResponse getAuthInfo(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    public AuthInfoResponse getAuthInfo(Member member) {
         return AuthInfoResponse.of(member);
     }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/member/service/MemberService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/service/MemberService.java
@@ -24,9 +24,7 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberInfoResponse updateMember(Long memberId, UpdateMemberRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    public MemberInfoResponse updateMember(Member member, UpdateMemberRequest request) {
         member.updateMember(request.comment(), request.profileImageUrl());
         return MemberInfoResponse.from(member);
     }

--- a/src/main/java/kr/dgucaps/caps/domain/member/service/TokenService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/service/TokenService.java
@@ -3,6 +3,7 @@ package kr.dgucaps.caps.domain.member.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.dgucaps.caps.domain.member.dto.response.MemberTokenResponse;
+import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.domain.member.entity.Role;
 import kr.dgucaps.caps.domain.member.repository.MemberRepository;
 import kr.dgucaps.caps.domain.redis.entity.RefreshToken;
@@ -127,7 +128,7 @@ public class TokenService {
         response.addHeader("Set-Cookie", refreshCookie.toString());
     }
 
-    public void logout(Long memberId) {
-        refreshTokenRepository.deleteById(memberId.toString());
+    public void logout(Member member) {
+        refreshTokenRepository.deleteById(member.getId().toString());
     }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/wiki/controller/WikiApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/wiki/controller/WikiApi.java
@@ -25,10 +25,12 @@ public interface WikiApi {
             summary = "위키 작성",
             description = "위키를 작성합니다."
     )
-    @ApiResponse(responseCode = "200", description = "위키 작성 성공",
-            content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = WikiResponse.class))
-    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "위키 작성 성공",
+                content = @Content(mediaType = "application/json",
+                        schema = @Schema(implementation = WikiResponse.class))),
+        @ApiResponse(responseCode = "409", description = "이미 존재하는 위키 제목")
+    })
     ResponseEntity<SuccessResponse<?>> createWiki(@AuthenticationPrincipal(expression = "member") Member member,
                                                   @Valid @RequestBody CreateOrModifyWikiRequest request);
 

--- a/src/main/java/kr/dgucaps/caps/domain/wiki/controller/WikiApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/wiki/controller/WikiApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.domain.wiki.dto.request.CreateOrModifyWikiRequest;
 import kr.dgucaps.caps.domain.wiki.dto.response.WikiResponse;
 import kr.dgucaps.caps.domain.wiki.dto.response.WikiTitleResponse;
@@ -28,7 +29,7 @@ public interface WikiApi {
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = WikiResponse.class))
     )
-    ResponseEntity<SuccessResponse<?>> createWiki(@AuthenticationPrincipal Long memberId,
+    ResponseEntity<SuccessResponse<?>> createWiki(@AuthenticationPrincipal(expression = "member") Member member,
                                                   @Valid @RequestBody CreateOrModifyWikiRequest request);
 
     @Operation(
@@ -39,7 +40,7 @@ public interface WikiApi {
             content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = WikiResponse.class))
     )
-    ResponseEntity<SuccessResponse<?>> modifyWiki(@AuthenticationPrincipal Long memberId,
+    ResponseEntity<SuccessResponse<?>> modifyWiki(@AuthenticationPrincipal(expression = "member") Member member,
                                                   @Valid @RequestBody CreateOrModifyWikiRequest request);
 
     @Operation(

--- a/src/main/java/kr/dgucaps/caps/domain/wiki/controller/WikiController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/wiki/controller/WikiController.java
@@ -1,6 +1,7 @@
 package kr.dgucaps.caps.domain.wiki.controller;
 
 import jakarta.validation.Valid;
+import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.domain.wiki.dto.request.CreateOrModifyWikiRequest;
 import kr.dgucaps.caps.domain.wiki.service.WikiService;
 import kr.dgucaps.caps.global.common.SuccessResponse;
@@ -19,16 +20,16 @@ public class WikiController implements WikiApi {
 
     @PreAuthorize("hasAnyRole('MEMBER', 'GRADUATE', 'COUNCIL', 'PRESIDENT', 'ADMIN')")
     @PostMapping
-    public ResponseEntity<SuccessResponse<?>> createWiki(@AuthenticationPrincipal Long memberId,
+    public ResponseEntity<SuccessResponse<?>> createWiki(@AuthenticationPrincipal(expression = "member") Member member,
                                                          @Valid @RequestBody CreateOrModifyWikiRequest request) {
-        return SuccessResponse.ok(wikiService.createWiki(memberId, request));
+        return SuccessResponse.ok(wikiService.createWiki(member, request));
     }
 
     @PreAuthorize("hasAnyRole('MEMBER', 'GRADUATE', 'COUNCIL', 'PRESIDENT', 'ADMIN')")
     @PatchMapping
-    public ResponseEntity<SuccessResponse<?>> modifyWiki(@AuthenticationPrincipal Long memberId,
+    public ResponseEntity<SuccessResponse<?>> modifyWiki(@AuthenticationPrincipal(expression = "member") Member member,
                                                          @Valid @RequestBody CreateOrModifyWikiRequest request) {
-        return SuccessResponse.ok(wikiService.modifyWiki(memberId, request));
+        return SuccessResponse.ok(wikiService.modifyWiki(member, request));
     }
 
     @GetMapping("/{title}")

--- a/src/main/java/kr/dgucaps/caps/domain/wiki/repository/WikiRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/wiki/repository/WikiRepository.java
@@ -22,4 +22,5 @@ public interface WikiRepository extends JpaRepository<Wiki, Long> {
 
     List<Wiki> findByJamoStartsWith(String jamo);
 
+    boolean existsByTitle(String title);
 }

--- a/src/main/java/kr/dgucaps/caps/domain/wiki/service/WikiService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/wiki/service/WikiService.java
@@ -10,6 +10,7 @@ import kr.dgucaps.caps.domain.wiki.repository.WikiHistoryRepository;
 import kr.dgucaps.caps.domain.wiki.repository.WikiRepository;
 import kr.dgucaps.caps.domain.wiki.util.WikiJamoUtils;
 import kr.dgucaps.caps.global.error.ErrorCode;
+import kr.dgucaps.caps.global.error.exception.ConflictException;
 import kr.dgucaps.caps.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,9 @@ public class WikiService {
 
     @Transactional
     public WikiResponse createWiki(Member member, CreateOrModifyWikiRequest request) {
+        if (wikiRepository.existsByTitle(request.title())) {
+            throw new ConflictException(ErrorCode.WIKI_ALREADY_EXISTS);
+        }
         Wiki savedWiki = wikiRepository.save(request.toEntity(member));
         return WikiResponse.from(savedWiki);
     }

--- a/src/main/java/kr/dgucaps/caps/domain/wiki/service/WikiService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/wiki/service/WikiService.java
@@ -1,7 +1,6 @@
 package kr.dgucaps.caps.domain.wiki.service;
 
 import kr.dgucaps.caps.domain.member.entity.Member;
-import kr.dgucaps.caps.domain.member.repository.MemberRepository;
 import kr.dgucaps.caps.domain.wiki.dto.request.CreateOrModifyWikiRequest;
 import kr.dgucaps.caps.domain.wiki.dto.response.WikiResponse;
 import kr.dgucaps.caps.domain.wiki.dto.response.WikiTitleResponse;
@@ -25,21 +24,16 @@ import java.util.stream.Collectors;
 public class WikiService {
 
     private final WikiRepository wikiRepository;
-    private final MemberRepository memberRepository;
     private final WikiHistoryRepository wikiHistoryRepository;
 
     @Transactional
-    public WikiResponse createWiki(Long memberId, CreateOrModifyWikiRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    public WikiResponse createWiki(Member member, CreateOrModifyWikiRequest request) {
         Wiki savedWiki = wikiRepository.save(request.toEntity(member));
         return WikiResponse.from(savedWiki);
     }
 
     @Transactional
-    public WikiResponse modifyWiki(Long memberId, CreateOrModifyWikiRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    public WikiResponse modifyWiki(Member member, CreateOrModifyWikiRequest request) {
         Wiki wiki = wikiRepository.findByTitle(request.title())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.WIKI_NOT_FOUND));
         WikiHistory wikiHistory = WikiHistory.builder()

--- a/src/main/java/kr/dgucaps/caps/global/config/auth/SecurityConfig.java
+++ b/src/main/java/kr/dgucaps/caps/global/config/auth/SecurityConfig.java
@@ -1,5 +1,6 @@
 package kr.dgucaps.caps.global.config.auth;
 
+import kr.dgucaps.caps.domain.member.repository.MemberRepository;
 import kr.dgucaps.caps.domain.member.service.KakaoOAuth2UserService;
 import kr.dgucaps.caps.global.config.CorsConfig;
 import kr.dgucaps.caps.global.config.auth.jwt.JwtAuthenticationEntryPoint;
@@ -8,6 +9,7 @@ import kr.dgucaps.caps.global.config.auth.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -18,9 +20,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-@RequiredArgsConstructor
-@EnableWebSecurity
 @Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
@@ -28,6 +31,7 @@ public class SecurityConfig {
     private final KakaoOAuth2UserService kakaoOAuth2UserService;
     private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
     private final CorsConfig corsConfig;
+    private final MemberRepository memberRepository;
 
     // 토큰 없이 접근 가능한 URL
     private static final String[] whiteList = {"/",
@@ -70,7 +74,7 @@ public class SecurityConfig {
                                 .anyRequest().authenticated()
                 )
                 .addFilter(corsConfig.corsFilter())
-                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, memberRepository), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)
                 .build();
     }

--- a/src/main/java/kr/dgucaps/caps/global/config/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/dgucaps/caps/global/config/auth/jwt/JwtAuthenticationFilter.java
@@ -71,7 +71,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 null,
                 List.of(new SimpleGrantedAuthority(member.getRole().getAuthority()))
         );
-        System.out.println("💡 GrantedAuthority: " + authentication.getAuthorities());
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }

--- a/src/main/java/kr/dgucaps/caps/global/config/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/dgucaps/caps/global/config/auth/jwt/JwtAuthenticationFilter.java
@@ -5,9 +5,14 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import kr.dgucaps.caps.domain.member.entity.Role;
+import kr.dgucaps.caps.domain.member.dto.CustomOAuth2User;
+import kr.dgucaps.caps.domain.member.entity.Member;
+import kr.dgucaps.caps.domain.member.repository.MemberRepository;
 import kr.dgucaps.caps.global.config.auth.UserAuthentication;
+import kr.dgucaps.caps.global.error.ErrorCode;
+import kr.dgucaps.caps.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.StringUtils;
@@ -15,15 +20,16 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION = "Authorization";
-
     private static final String BEARER = "Bearer ";
 
     private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -32,9 +38,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 유효성 검증
             jwtProvider.validateAccessToken(token);
             final Long memberId = jwtProvider.getSubject(token);
-            final Role role = jwtProvider.getRole(token);
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
             // 인증 정보 설정
-            setAuthentication(request, memberId, role);
+            setAuthentication(request, member);
         }
         filterChain.doFilter(request, response);
     }
@@ -57,8 +64,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return null;
     }
 
-    private void setAuthentication(HttpServletRequest request, Long memberId, Role role) {
-        UserAuthentication authentication = new UserAuthentication(memberId, null, List.of(role));
+    private void setAuthentication(HttpServletRequest request, Member member) {
+        CustomOAuth2User principal = new CustomOAuth2User(member, Map.of(), "id");
+        UserAuthentication authentication = new UserAuthentication(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority(member.getRole().getAuthority()))
+        );
+        System.out.println("💡 GrantedAuthority: " + authentication.getAuthorities());
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }

--- a/src/main/java/kr/dgucaps/caps/global/error/ErrorCode.java
+++ b/src/main/java/kr/dgucaps/caps/global/error/ErrorCode.java
@@ -41,7 +41,8 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M002", "사용자가 존재하지 않습니다."),
 
     // Wiki
-    WIKI_NOT_FOUND(HttpStatus.NOT_FOUND, "W001", "위키가 존재하지 않습니다.")
+    WIKI_NOT_FOUND(HttpStatus.NOT_FOUND, "W001", "위키가 존재하지 않습니다."),
+    WIKI_ALREADY_EXISTS(HttpStatus.CONFLICT, "W002", "이미 존재하는 위키입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/dgucaps/caps/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/kr/dgucaps/caps/global/error/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -92,6 +94,16 @@ public class GlobalExceptionHandler {
         log.error(">>> handle: MaxUploadSizeExceededException (파일 크기 초과)", e);
         final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.FILE_SIZE_EXCEEDED);
         return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(errorResponse);
+    }
+
+    /**
+     * 권한이 없는 사용자가 접근할 때 발생하는 error를 handling합니다.
+     */
+    @ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(Exception e) {
+        log.warn(">>> handle: AccessDeniedException or AuthorizationDeniedException", e);
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.FORBIDDEN);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
     }
 
     /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #11 
- close : #11 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 위키 중복 생성 방지 로직 구현
- JWT에서 사용자 정보 불러오는 방식 수정
- 인증 정보 조회 API 추가

## 📸 스크린샷
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->