### PR TITLE
[bug] WikiController 오류 관련 빌드 실패

### DIFF
--- a/src/main/java/kr/dgucaps/caps/domain/wiki/controller/WikiController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/wiki/controller/WikiController.java
@@ -22,7 +22,7 @@ public class WikiController implements WikiApi {
     @PostMapping
     public ResponseEntity<SuccessResponse<?>> createWiki(@AuthenticationPrincipal(expression = "member") Member member,
                                                          @Valid @RequestBody CreateOrModifyWikiRequest request) {
-        return SuccessResponse.created(wikiService.createWiki(memberId, request));
+        return SuccessResponse.created(wikiService.createWiki(member, request));
     }
 
     @PreAuthorize("hasAnyRole('MEMBER', 'GRADUATE', 'COUNCIL', 'PRESIDENT', 'ADMIN')")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #14
- close : #14
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- createWiki 메서드가 memberId 대신 Member 엔티티를 사용하도록 수정

## 📸 스크린샷
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->