### PR TITLE
feat: #37 문의 신고 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
 	// aws s3
 	implementation 'software.amazon.awssdk:s3:2.20.26'
 	implementation 'software.amazon.awssdk:url-connection-client:2.20.26'

--- a/src/main/java/kr/dgucaps/caps/domain/report/controller/ReportApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/controller/ReportApi.java
@@ -1,0 +1,32 @@
+package kr.dgucaps.caps.domain.report.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.dgucaps.caps.domain.report.dto.request.CreateReportRequest;
+import kr.dgucaps.caps.domain.report.dto.response.ReportResponse;
+import kr.dgucaps.caps.global.annotation.Auth;
+import kr.dgucaps.caps.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Report", description = "문의 신고 API")
+public interface ReportApi {
+    @Operation(
+            summary = "문의 및 신고 작성",
+            description = "문의 및 신고 내용을 서버에 제출합니다"
+    )
+    @ApiResponse(responseCode = "200", description = "문의 및 신고 성공",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = ReportResponse.class))
+    )
+    @PreAuthorize("hasAnyRole('MEMBER', 'GRADUATE', 'COUNCIL', 'PRESIDENT', 'ADMIN')")
+    ResponseEntity<SuccessResponse<?>> createReport(
+            @Auth Long memberId,
+            @RequestBody @Valid CreateReportRequest request
+    );
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/controller/ReportController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/controller/ReportController.java
@@ -1,0 +1,34 @@
+package kr.dgucaps.caps.domain.report.controller;
+
+import jakarta.validation.Valid;
+import kr.dgucaps.caps.domain.report.dto.request.CreateReportRequest;
+import kr.dgucaps.caps.domain.report.service.ReportService;
+import kr.dgucaps.caps.global.annotation.Auth;
+import kr.dgucaps.caps.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/report")
+public class ReportController implements ReportApi {
+
+    private final ReportService reportService;
+
+    @PreAuthorize("hasAnyRole('MEMBER', 'GRADUATE', 'COUNCIL', 'PRESIDENT', 'ADMIN')")
+    @Override
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> createReport(
+            @Auth Long memberId,
+            @RequestBody @Valid CreateReportRequest request
+    ) {
+        return SuccessResponse.ok(reportService.createReport(memberId, request));
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/dto/request/CreateReportRequest.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/dto/request/CreateReportRequest.java
@@ -1,0 +1,20 @@
+package kr.dgucaps.caps.domain.report.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import kr.dgucaps.caps.domain.member.entity.Member;
+import kr.dgucaps.caps.domain.report.entity.Category;
+import kr.dgucaps.caps.domain.report.entity.Report;
+
+public record CreateReportRequest(
+        @NotBlank String content,
+        String[] fileUrls,
+        Category category
+) {
+    public Report toReportEntity(Member member) {
+        return Report.builder()
+                .member(member)
+                .content(content)
+                .category(category)
+                .build();
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/dto/response/ReportResponse.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/dto/response/ReportResponse.java
@@ -1,0 +1,24 @@
+package kr.dgucaps.caps.domain.report.dto.response;
+
+import kr.dgucaps.caps.domain.report.entity.Category;
+import kr.dgucaps.caps.domain.report.entity.Report;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ReportResponse(
+        Integer id,
+        String content,
+        Category category,
+        List<String> fileUrls
+) {
+    public static ReportResponse from(Report report, List<String> fileUrls) {
+        return ReportResponse.builder()
+                .id(report.getId())
+                .content(report.getContent())
+                .category(report.getCategory())
+                .fileUrls(fileUrls)
+                .build();
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/entity/Category.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/entity/Category.java
@@ -1,0 +1,21 @@
+package kr.dgucaps.caps.domain.report.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+    INFO_ERROR("정보 오류"),
+    ACCOUNT_MANAGEMENT("계정 관리"),
+    SUGGESTION("건의사항"),
+    USER_REPORT_AND_SECURITY_REPORT("유저 신고 및 보안 제보"),
+    ETC("기타");
+    private final String title;
+
+    public String toJson() {
+        return title;
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/entity/Category.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/entity/Category.java
@@ -14,8 +14,4 @@ public enum Category {
     USER_REPORT_AND_SECURITY_REPORT("유저 신고 및 보안 제보"),
     ETC("기타");
     private final String title;
-
-    public String toJson() {
-        return title;
-    }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/report/entity/Report.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/entity/Report.java
@@ -1,0 +1,37 @@
+package kr.dgucaps.caps.domain.report.entity;
+
+import jakarta.persistence.*;
+import kr.dgucaps.caps.domain.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "report")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Builder
+    public Report(Member member, String content, Category category) {
+        this.member = member;
+        this.content = content;
+        this.category = category;
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/entity/ReportFile.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/entity/ReportFile.java
@@ -19,7 +19,7 @@ public class ReportFile {
     @JoinColumn(name = "report_id", nullable = false)
     private Report report;
 
-    @Column(name = "file_url", nullable = false, length = 127)
+    @Column(name = "file_url", nullable = false, length = 256)
     private String fileUrl;
 
     public ReportFile(Report report, String fileUrl) {

--- a/src/main/java/kr/dgucaps/caps/domain/report/entity/ReportFile.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/entity/ReportFile.java
@@ -1,0 +1,29 @@
+package kr.dgucaps.caps.domain.report.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "report_file")
+public class ReportFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "report_id", nullable = false)
+    private Report report;
+
+    @Column(name = "file_url", nullable = false, length = 127)
+    private String fileUrl;
+
+    public ReportFile(Report report, String fileUrl) {
+        this.report = report;
+        this.fileUrl = fileUrl;
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/integration/DiscordWebhookSender.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/integration/DiscordWebhookSender.java
@@ -1,0 +1,40 @@
+package kr.dgucaps.caps.domain.report.integration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class DiscordWebhookSender {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${discord.webhook.uri}")
+    private String webhookUri;
+
+    @Value("${discord.webhook.name:CAPS Report}")
+    private String webhookName;
+
+    public void send(String message) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = Map.of(
+                "username", webhookName,
+                "content", truncate(message, 1800)
+        );
+
+        restTemplate.postForEntity(webhookUri, new HttpEntity<>(body, headers), String.class);
+    }
+
+    private String truncate(String s, int max) {
+        if (s == null) return "";
+        if (s.length() <= max) return s;
+        return s.substring(0, max - 3) + "...";
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/integration/ReportCreatedEvent.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/integration/ReportCreatedEvent.java
@@ -1,0 +1,10 @@
+package kr.dgucaps.caps.domain.report.integration;
+
+import kr.dgucaps.caps.domain.report.entity.Report;
+
+import java.util.List;
+
+public record ReportCreatedEvent(
+        Report report,
+        List<String> fileUrls
+) {}

--- a/src/main/java/kr/dgucaps/caps/domain/report/integration/ReportDiscordWebhookListener.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/integration/ReportDiscordWebhookListener.java
@@ -1,0 +1,59 @@
+package kr.dgucaps.caps.domain.report.integration;
+
+import kr.dgucaps.caps.domain.member.entity.Member;
+import kr.dgucaps.caps.domain.report.entity.Report;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReportDiscordWebhookListener {
+
+    private final DiscordWebhookSender discordWebhookSender;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onReportCreated(ReportCreatedEvent event) {
+        try {
+            String files = (event.fileUrls() == null || event.fileUrls().isEmpty())
+                    ? "(없음)"
+                    : String.join("\n", event.fileUrls());
+
+            String msg = getString(event, files);
+            discordWebhookSender.send(msg);
+        } catch (Exception e) {
+            log.warn("Discord webhook failed after commit. reportId={}", event.report().getId(), e);
+        }
+    }
+
+    private static @NonNull String getString(ReportCreatedEvent event, String files) {
+        Report report = event.report();
+        Member member = report.getMember();
+
+        return """
+            ❤️ **문의/신고 등록** ❤️
+            
+            문의 번호: #%s
+            문의 유형: %s
+            
+            문의자: %s기 %s
+            문의 내용: %s
+            
+            파일
+            %s
+            
+            **✅ 해결 시 체크 표시를 남겨주세요!**
+                """.formatted(
+                report.getId(),
+                report.getCategory().toJson(),
+                member.getGrade(),
+                member.getName(),
+                report.getContent(),
+                files
+        );
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/integration/ReportDiscordWebhookListener.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/integration/ReportDiscordWebhookListener.java
@@ -49,7 +49,7 @@ public class ReportDiscordWebhookListener {
             **✅ 해결 시 체크 표시를 남겨주세요!**
                 """.formatted(
                 report.getId(),
-                report.getCategory().toJson(),
+                report.getCategory().getTitle(),
                 member.getGrade(),
                 member.getName(),
                 report.getContent(),

--- a/src/main/java/kr/dgucaps/caps/domain/report/repository/ReportFileRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/repository/ReportFileRepository.java
@@ -1,0 +1,7 @@
+package kr.dgucaps.caps.domain.report.repository;
+
+import kr.dgucaps.caps.domain.report.entity.ReportFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportFileRepository extends JpaRepository<ReportFile, Integer> {
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/repository/ReportRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/repository/ReportRepository.java
@@ -1,0 +1,8 @@
+package kr.dgucaps.caps.domain.report.repository;
+
+import kr.dgucaps.caps.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Integer> {
+    
+}

--- a/src/main/java/kr/dgucaps/caps/domain/report/service/ReportService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/report/service/ReportService.java
@@ -1,0 +1,63 @@
+package kr.dgucaps.caps.domain.report.service;
+
+import kr.dgucaps.caps.domain.member.entity.Member;
+import kr.dgucaps.caps.domain.member.repository.MemberRepository;
+import kr.dgucaps.caps.domain.report.dto.request.CreateReportRequest;
+import kr.dgucaps.caps.domain.report.dto.response.ReportResponse;
+import kr.dgucaps.caps.domain.report.entity.Report;
+import kr.dgucaps.caps.domain.report.entity.ReportFile;
+import kr.dgucaps.caps.domain.report.integration.ReportCreatedEvent;
+import kr.dgucaps.caps.domain.report.repository.ReportFileRepository;
+import kr.dgucaps.caps.domain.report.repository.ReportRepository;
+import kr.dgucaps.caps.global.error.ErrorCode;
+import kr.dgucaps.caps.global.error.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+    private final MemberRepository memberRepository;
+    private final ReportRepository reportRepository;
+    private final ReportFileRepository reportFileRepository;
+    private final ApplicationEventPublisher publisher;
+
+
+    private List<ReportFile> getReportFiles(Report report, String[] fileUrls) {
+        if (fileUrls == null) {
+            return List.of();
+        }
+        return Arrays.stream(fileUrls)
+                .filter(url -> url != null && !url.isBlank())
+                .map(url -> new ReportFile(report, url))
+                .toList();
+    }
+
+    @Transactional
+    public ReportResponse createReport(Long memberId, CreateReportRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Report report = reportRepository.save(request.toReportEntity(member));
+
+        List<ReportFile> files = getReportFiles(report, request.fileUrls());
+        if (!files.isEmpty()) {
+            reportFileRepository.saveAll(files);
+        }
+        List<String> urls = files.stream()
+                .map(ReportFile::getFileUrl)
+                .toList();
+
+        publisher.publishEvent(new ReportCreatedEvent(
+                report,
+                urls
+        ));
+
+        return ReportResponse.from(report, urls);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #37 

## 📝 작업 내용
- Report(문의/신고) 작성 API 구현 (POST /api/v1/report)
- ReportService에서 신고 내용 저장 + 첨부 파일 URL 리스트 저장 로직 추가

## 📸 스크린샷
<img width="906" height="1086" alt="image" src="https://github.com/user-attachments/assets/99e95edb-d5c8-466f-82ef-64037e932b6f" />
<img width="1418" height="1145" alt="image" src="https://github.com/user-attachments/assets/0ba0adf7-5ee1-4526-936f-bc20fb263fd0" />


## 📢 참고 사항
