### PR TITLE
feat: 위키 조회 API 로그인 전용 전환

### DIFF
--- a/src/main/java/kr/dgucaps/caps/global/config/auth/SecurityConfig.java
+++ b/src/main/java/kr/dgucaps/caps/global/config/auth/SecurityConfig.java
@@ -38,10 +38,6 @@ public class SecurityConfig {
 
             /* api */
             "api/v1/auth/reissue",
-            "api/v1/wikis/*",
-            "api/v1/wikis/recent",
-            "api/v1/wikis/random",
-            "api/v1/wikis/*/history",
     };
 
     @Bean


### PR DESCRIPTION
## Summary
`SecurityConfig`의 whiteList(토큰 없이 접근 가능한 URL)에서 위키 공개 항목을 제거해, `/api/v1/wikis/**` 조회 전체가 로그인(ACCESS 권한)을 요구하도록 변경.

```diff
             "api/v1/auth/reissue",
-            "api/v1/wikis/*",
-            "api/v1/wikis/recent",
-            "api/v1/wikis/random",
-            "api/v1/wikis/*/history",
     };
```

비로그인 상태에서 위키 본문·수정내역이 그대로 열람되던 문제를 해결한다. (curl로 익명 200 응답 확인됨)

## ⚠️ 배포 순서
프론트(`caps-client`)에서 위키 라우트 `ProtectedRoute` 적용 + 평문 axios 호출에 `withCredentials` 추가 변경이 **먼저 배포**되어야 로그인 사용자 위키가 정상 동작함.
- 관련 프론트 PR: CAPS-DGU/caps-client#106 (develop 머지 완료), #107 (→main 대기)
- **프론트 선배포 → 본 백엔드 후배포** 순서 권장 (반대면 구버전 프론트가 401을 처리 못 해 위키가 깨짐)

## 참고
- 위키 생성/수정은 기존대로 `@PreAuthorize`로 MEMBER+ 역할 요구(변경 없음)
- `autocomplete`는 whiteList의 `wikis/*` 매칭으로 그동안 공개였으나 이번 변경으로 함께 로그인 필요가 됨(프론트는 이미 토큰 포함 호출)

🤖 Generated with [Claude Code](https://claude.com/claude-code)