### PR TITLE
Security/member access and file ownership

### DIFF
--- a/src/main/java/kr/dgucaps/caps/domain/file/controller/FileController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/file/controller/FileController.java
@@ -42,8 +42,8 @@ public class FileController {
         return SuccessResponse.ok(Map.of("downloadURL", presignedUrl));
     }
 
-    // 파일 삭제
-    @PreAuthorize("hasAnyRole('MEMBER', 'GRADUATE', 'COUNCIL', 'PRESIDENT', 'ADMIN')")
+    // 파일 삭제 (임의 삭제 방지를 위해 관리자만 허용)
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping
     public ResponseEntity<SuccessResponse<?>> deleteFile(
             @RequestParam("key") @NotBlank String fileKey) {

--- a/src/main/java/kr/dgucaps/caps/domain/member/controller/MemberApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/controller/MemberApi.java
@@ -28,16 +28,18 @@ public interface MemberApi {
     ResponseEntity<SuccessResponse<?>> getMemberInfo(Long memberId);
 
     @Operation(
-            summary = "다른 회원 정보 조회",
-            description = "본인이 아닌 회원을 번호로 조회합니다."
+            summary = "회원 정보 번호 조회",
+            description = "회원 번호로 조회합니다. 개인정보 보호를 위해 본인 번호만 조회할 수 있습니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "다른 회원 정보 조회 성공",
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = MemberInfoResponse.class))),
+            @ApiResponse(responseCode = "403", description = "본인이 아닌 회원 조회 시도"),
             @ApiResponse(responseCode = "404", description = "회원이 존재하지 않음")
     })
-    ResponseEntity<SuccessResponse<?>> getOtherMemberInfo(@PathVariable("memberId") Long memberId);
+    ResponseEntity<SuccessResponse<?>> getOtherMemberInfo(Long authMemberId,
+                                                          @PathVariable("memberId") Long memberId);
 
     @Operation(
             summary = "내 정보 수정",

--- a/src/main/java/kr/dgucaps/caps/domain/member/controller/MemberController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import kr.dgucaps.caps.domain.member.dto.request.UpdateMemberRequest;
 import kr.dgucaps.caps.domain.member.service.MemberService;
 import kr.dgucaps.caps.global.annotation.Auth;
 import kr.dgucaps.caps.global.common.SuccessResponse;
+import kr.dgucaps.caps.global.error.exception.ForbiddenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,7 +23,12 @@ public class MemberController implements MemberApi {
     }
 
     @GetMapping("/{memberId}")
-    public ResponseEntity<SuccessResponse<?>> getOtherMemberInfo(@PathVariable("memberId") Long memberId) {
+    public ResponseEntity<SuccessResponse<?>> getOtherMemberInfo(@Auth Long authMemberId,
+                                                                 @PathVariable("memberId") Long memberId) {
+        // 본인 정보만 조회 가능 (타인의 학번·전화번호·이메일 등 개인정보 노출 방지)
+        if (!authMemberId.equals(memberId)) {
+            throw new ForbiddenException();
+        }
         return SuccessResponse.ok(memberService.getMemberInfo(memberId));
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #61 

## 📝 작업 내용
- 회원 정보 번호 조회(`GET /api/v1/members/{memberId}`)를 본인 번호로만 조회 가능하도록 제한했습니다. 타인의 학번·전화번호·이메일 등 개인정보가 노출되던 문제를 방지하고, 본인이 아닌 회원 조회 시 403을 반환합니다.
- 파일 삭제(`DELETE /api/v1/files`) 권한을 관리자(ADMIN)로 제한했습니다. 파일 소유권 검증 없이 S3 key만 알면 누구나 파일을 삭제할 수 있던 문제를 방지합니다.

## 📢 참고 사항
- 파일 삭제는 현재 소유권을 저장하는 DB가 없어 우선 ADMIN 전용으로 제한했습니다. 집행부/회장도 삭제가 필요하거나, 일반 회원이 본인 업로드 파일을 직접 삭제하는 UX가 필요하면 업로드 key에 사용자 prefix를 강제하거나 소유권 테이블을 두는 방식으로 후속 작업이 필요합니다.