### PR TITLE
Feat/#66 blog

### DIFF
--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import kr.dgucaps.caps.domain.blog.dto.request.CreateOrModifyBlogRequest;
 import kr.dgucaps.caps.domain.blog.dto.response.BlogListResponse;
 import kr.dgucaps.caps.domain.blog.dto.response.BlogResponse;
 import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
@@ -16,6 +17,7 @@ import kr.dgucaps.caps.global.annotation.Auth;
 import kr.dgucaps.caps.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Blog", description = "블로그 API")
@@ -38,17 +40,32 @@ public interface BlogApi {
 
     @Operation(
             summary = "게시물 상세 조회",
-            description = "게시물 상세 내용을 조회합니다. 조회 시 viewCount가 1 증가하며, API 응답에는 포함되지 않습니다."
+            description = "게시물 상세 내용을 조회합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시물 상세 조회 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = BlogResponse.class))),
             @ApiResponse(responseCode = "403", description = "비공개 처리된 게시물입니다."),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물")
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물입니다.")
     })
     ResponseEntity<SuccessResponse<?>> getBlog(
             @PathVariable("blogId") Integer blogId,
             @Auth Long memberId
+    );
+
+    @Operation(
+            summary = "게시물 작성",
+            description = "새 블로그 게시물을 작성합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "게시물 작성 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = BlogResponse.class))),
+            @ApiResponse(responseCode = "401", description = "게시물을 작성할 권한이 없습니다.")
+    })
+    ResponseEntity<SuccessResponse<?>> createBlog(
+            @Auth Long memberId,
+            @RequestBody @Valid CreateOrModifyBlogRequest request
     );
 }

--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogApi.java
@@ -1,0 +1,36 @@
+package kr.dgucaps.caps.domain.blog.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import kr.dgucaps.caps.domain.blog.dto.response.BlogListResponse;
+import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
+import kr.dgucaps.caps.global.annotation.Auth;
+import kr.dgucaps.caps.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Blog", description = "블로그 API")
+public interface BlogApi {
+
+    @Operation(
+            summary = "게시물 목록 조회",
+            description = "카테고리별 게시물 목록을 조회합니다. 비공개 게시물은 작성자/PRESIDENT/ADMIN에게만 노출됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시물 목록 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = BlogListResponse.class)))
+    })
+    ResponseEntity<SuccessResponse<?>> getBlogs(
+            @RequestParam("category") @NotNull BlogCategory category,
+            @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) Integer page,
+            @Auth Long memberId
+    );
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogApi.java
@@ -10,10 +10,12 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import kr.dgucaps.caps.domain.blog.dto.response.BlogListResponse;
+import kr.dgucaps.caps.domain.blog.dto.response.BlogResponse;
 import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
 import kr.dgucaps.caps.global.annotation.Auth;
 import kr.dgucaps.caps.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Blog", description = "블로그 API")
@@ -31,6 +33,22 @@ public interface BlogApi {
     ResponseEntity<SuccessResponse<?>> getBlogs(
             @RequestParam("category") @NotNull BlogCategory category,
             @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) Integer page,
+            @Auth Long memberId
+    );
+
+    @Operation(
+            summary = "게시물 상세 조회",
+            description = "게시물 상세 내용을 조회합니다. 조회 시 viewCount가 1 증가하며, API 응답에는 포함되지 않습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시물 상세 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = BlogResponse.class))),
+            @ApiResponse(responseCode = "403", description = "비공개 처리된 게시물입니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물")
+    })
+    ResponseEntity<SuccessResponse<?>> getBlog(
+            @PathVariable("blogId") Integer blogId,
             @Auth Long memberId
     );
 }

--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogApi.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import kr.dgucaps.caps.domain.blog.dto.request.CreateOrModifyBlogRequest;
 import kr.dgucaps.caps.domain.blog.dto.response.BlogListResponse;
 import kr.dgucaps.caps.domain.blog.dto.response.BlogResponse;
@@ -25,7 +24,7 @@ public interface BlogApi {
 
     @Operation(
             summary = "게시물 목록 조회",
-            description = "카테고리별 게시물 목록을 조회합니다. 비공개 게시물은 작성자/PRESIDENT/ADMIN에게만 노출됩니다."
+            description = "게시물 목록을 조회합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시물 목록 조회 성공",
@@ -33,9 +32,8 @@ public interface BlogApi {
                             schema = @Schema(implementation = BlogListResponse.class)))
     })
     ResponseEntity<SuccessResponse<?>> getBlogs(
-            @RequestParam("category") @NotNull BlogCategory category,
-            @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) Integer page,
-            @Auth Long memberId
+            @RequestParam(value = "category", required = false) BlogCategory category,
+            @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) Integer page
     );
 
     @Operation(
@@ -50,8 +48,7 @@ public interface BlogApi {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물입니다.")
     })
     ResponseEntity<SuccessResponse<?>> getBlog(
-            @PathVariable("blogId") Integer blogId,
-            @Auth Long memberId
+            @PathVariable("blogId") Integer blogId
     );
 
     @Operation(
@@ -62,7 +59,7 @@ public interface BlogApi {
             @ApiResponse(responseCode = "201", description = "게시물 작성 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = BlogResponse.class))),
-            @ApiResponse(responseCode = "401", description = "게시물을 작성할 권한이 없습니다.")
+            @ApiResponse(responseCode = "403", description = "게시물을 작성할 권한이 없습니다.")
     })
     ResponseEntity<SuccessResponse<?>> createBlog(
             @Auth Long memberId,
@@ -77,7 +74,7 @@ public interface BlogApi {
             @ApiResponse(responseCode = "200", description = "게시물 수정 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = BlogResponse.class))),
-            @ApiResponse(responseCode = "401", description = "게시물을 수정할 권한이 없습니다."),
+            @ApiResponse(responseCode = "403", description = "게시물을 수정할 권한이 없습니다."),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물입니다.")
     })
     ResponseEntity<SuccessResponse<?>> modifyBlog(
@@ -92,7 +89,7 @@ public interface BlogApi {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "게시물 삭제 성공"),
-            @ApiResponse(responseCode = "401", description = "게시물을 삭제할 권한이 없습니다."),
+            @ApiResponse(responseCode = "403", description = "게시물을 삭제할 권한이 없습니다."),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물입니다.")
     })
     ResponseEntity<SuccessResponse<?>> deleteBlog(

--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogApi.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogApi.java
@@ -68,4 +68,34 @@ public interface BlogApi {
             @Auth Long memberId,
             @RequestBody @Valid CreateOrModifyBlogRequest request
     );
+
+    @Operation(
+            summary = "게시물 수정",
+            description = "기존 블로그 게시물을 수정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시물 수정 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = BlogResponse.class))),
+            @ApiResponse(responseCode = "401", description = "게시물을 수정할 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물입니다.")
+    })
+    ResponseEntity<SuccessResponse<?>> modifyBlog(
+            @Auth Long memberId,
+            @PathVariable("blogId") Integer blogId,
+            @RequestBody @Valid CreateOrModifyBlogRequest request
+    );
+
+    @Operation(
+            summary = "게시물 삭제",
+            description = "블로그 게시물을 삭제합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "게시물 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "게시물을 삭제할 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물입니다.")
+    })
+    ResponseEntity<SuccessResponse<?>> deleteBlog(
+            @PathVariable("blogId") Integer blogId
+    );
 }

--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
@@ -3,15 +3,19 @@ package kr.dgucaps.caps.domain.blog.controller;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import kr.dgucaps.caps.domain.blog.dto.request.CreateOrModifyBlogRequest;
 import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
 import kr.dgucaps.caps.domain.blog.service.BlogService;
 import kr.dgucaps.caps.global.annotation.Auth;
 import kr.dgucaps.caps.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,5 +45,15 @@ public class BlogController implements BlogApi {
             @Auth Long memberId
     ) {
         return SuccessResponse.ok(blogService.getBlogById(blogId, memberId));
+    }
+
+    // 게시물 작성
+    @PreAuthorize("hasAnyRole('PRESIDENT', 'ADMIN')")
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> createBlog(
+            @Auth Long memberId,
+            @RequestBody @Valid CreateOrModifyBlogRequest request
+    ) {
+        return SuccessResponse.created(blogService.createBlog(memberId, request));
     }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,7 +24,7 @@ public class BlogController implements BlogApi {
 
     private final BlogService blogService;
 
-    // 카테고리별 게시물 목록을 조회한다.
+    // 카테고리별 게시물 목록 조회
     @GetMapping
     public ResponseEntity<SuccessResponse<?>> getBlogs(
             @RequestParam("category") @NotNull BlogCategory category,
@@ -31,5 +32,14 @@ public class BlogController implements BlogApi {
             @Auth Long memberId
     ) {
         return SuccessResponse.ok(blogService.getBlogsByPage(category, page - 1, memberId));
+    }
+
+    // 게시물 상세 조회
+    @GetMapping("/{blogId}")
+    public ResponseEntity<SuccessResponse<?>> getBlog(
+            @PathVariable("blogId") Integer blogId,
+            @Auth Long memberId
+    ) {
+        return SuccessResponse.ok(blogService.getBlogById(blogId, memberId));
     }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
@@ -1,0 +1,35 @@
+package kr.dgucaps.caps.domain.blog.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
+import kr.dgucaps.caps.domain.blog.service.BlogService;
+import kr.dgucaps.caps.global.annotation.Auth;
+import kr.dgucaps.caps.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/blogs")
+@Validated
+public class BlogController implements BlogApi {
+
+    private final BlogService blogService;
+
+    // 카테고리별 게시물 목록을 조회한다.
+    @GetMapping
+    public ResponseEntity<SuccessResponse<?>> getBlogs(
+            @RequestParam("category") @NotNull BlogCategory category,
+            @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) Integer page,
+            @Auth Long memberId
+    ) {
+        return SuccessResponse.ok(blogService.getBlogsByPage(category, page - 1, memberId));
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
@@ -2,7 +2,6 @@ package kr.dgucaps.caps.domain.blog.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import kr.dgucaps.caps.domain.blog.dto.request.CreateOrModifyBlogRequest;
 import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
 import kr.dgucaps.caps.domain.blog.service.BlogService;
@@ -30,23 +29,21 @@ public class BlogController implements BlogApi {
 
     private final BlogService blogService;
 
-    // 카테고리별 게시물 목록 조회
+    // 게시물 목록 조회
     @GetMapping
     public ResponseEntity<SuccessResponse<?>> getBlogs(
-            @RequestParam("category") @NotNull BlogCategory category,
-            @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) Integer page,
-            @Auth Long memberId
+            @RequestParam(value = "category", required = false) BlogCategory category,
+            @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) Integer page
     ) {
-        return SuccessResponse.ok(blogService.getBlogsByPage(category, page - 1, memberId));
+        return SuccessResponse.ok(blogService.getBlogsByPage(category, page - 1));
     }
 
     // 게시물 상세 조회
     @GetMapping("/{blogId}")
     public ResponseEntity<SuccessResponse<?>> getBlog(
-            @PathVariable("blogId") Integer blogId,
-            @Auth Long memberId
+            @PathVariable("blogId") Integer blogId
     ) {
-        return SuccessResponse.ok(blogService.getBlogById(blogId, memberId));
+        return SuccessResponse.ok(blogService.getBlogById(blogId));
     }
 
     // 게시물 작성

--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
@@ -12,9 +12,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -48,12 +50,33 @@ public class BlogController implements BlogApi {
     }
 
     // 게시물 작성
-    @PreAuthorize("hasAnyRole('PRESIDENT', 'ADMIN')")
+    @PreAuthorize("hasAnyRole('COUNCIL', 'PRESIDENT', 'ADMIN')")
     @PostMapping
     public ResponseEntity<SuccessResponse<?>> createBlog(
             @Auth Long memberId,
             @RequestBody @Valid CreateOrModifyBlogRequest request
     ) {
         return SuccessResponse.created(blogService.createBlog(memberId, request));
+    }
+
+    // 게시물 수정
+    @PreAuthorize("hasAnyRole('COUNCIL', 'PRESIDENT', 'ADMIN')")
+    @PutMapping("/{blogId}")
+    public ResponseEntity<SuccessResponse<?>> modifyBlog(
+            @Auth Long memberId,
+            @PathVariable("blogId") Integer blogId,
+            @RequestBody @Valid CreateOrModifyBlogRequest request
+    ) {
+        return SuccessResponse.ok(blogService.modifyBlog(blogId, memberId, request));
+    }
+
+    // 게시물 삭제
+    @PreAuthorize("hasAnyRole('COUNCIL', 'PRESIDENT', 'ADMIN')")
+    @DeleteMapping("/{blogId}")
+    public ResponseEntity<SuccessResponse<?>> deleteBlog(
+            @PathVariable("blogId") Integer blogId
+    ) {
+        blogService.deleteBlog(blogId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/blog/dto/request/CreateOrModifyBlogRequest.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/dto/request/CreateOrModifyBlogRequest.java
@@ -1,0 +1,36 @@
+package kr.dgucaps.caps.domain.blog.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
+import kr.dgucaps.caps.domain.blog.entity.BlogPost;
+import kr.dgucaps.caps.domain.member.entity.Member;
+
+import java.util.List;
+
+public record CreateOrModifyBlogRequest(
+        @NotBlank String title,
+        String subtitle,
+        @NotBlank String content,
+        String thumbnailUrl,
+        @NotNull BlogCategory category,
+        @NotNull Boolean isPrivate,
+        @NotNull Float writerGrade,
+        @NotBlank String writerName,
+        List<String> fileUrls,
+        List<String> imageUrls
+) {
+    public BlogPost toEntity(Member member) {
+        return BlogPost.builder()
+                .member(member)
+                .title(title)
+                .subtitle(subtitle)
+                .content(content)
+                .thumbnailUrl(thumbnailUrl)
+                .category(category)
+                .isPrivate(isPrivate)
+                .writerGrade(writerGrade)
+                .writerName(writerName)
+                .build();
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/dto/response/BlogListResponse.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/dto/response/BlogListResponse.java
@@ -1,0 +1,34 @@
+package kr.dgucaps.caps.domain.blog.dto.response;
+
+import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
+import kr.dgucaps.caps.domain.blog.entity.BlogPost;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record BlogListResponse(
+        Integer id,
+        String title,
+        String subtitle,
+        String thumbnailUrl,
+        BlogCategory category,
+        boolean isPrivate,
+        Float writerGrade,
+        String writerName,
+        LocalDateTime createdAt
+) {
+    public static BlogListResponse from(BlogPost blogPost) {
+        return BlogListResponse.builder()
+                .id(blogPost.getId())
+                .title(blogPost.getTitle())
+                .subtitle(blogPost.getSubtitle())
+                .thumbnailUrl(blogPost.getThumbnailUrl())
+                .category(blogPost.getCategory())
+                .isPrivate(blogPost.isPrivate())
+                .writerGrade(blogPost.getWriterGrade())
+                .writerName(blogPost.getWriterName())
+                .createdAt(blogPost.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/dto/response/BlogResponse.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/dto/response/BlogResponse.java
@@ -1,0 +1,43 @@
+package kr.dgucaps.caps.domain.blog.dto.response;
+
+import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
+import kr.dgucaps.caps.domain.blog.entity.BlogFile;
+import kr.dgucaps.caps.domain.blog.entity.BlogImage;
+import kr.dgucaps.caps.domain.blog.entity.BlogPost;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record BlogResponse(
+        Integer id,
+        String title,
+        String subtitle,
+        String content,
+        String thumbnailUrl,
+        BlogCategory category,
+        boolean isPrivate,
+        Float writerGrade,
+        String writerName,
+        LocalDateTime createdAt,
+        List<String> fileUrls,
+        List<String> imageUrls
+) {
+    public static BlogResponse from(BlogPost blogPost) {
+        return BlogResponse.builder()
+                .id(blogPost.getId())
+                .title(blogPost.getTitle())
+                .subtitle(blogPost.getSubtitle())
+                .content(blogPost.getContent())
+                .thumbnailUrl(blogPost.getThumbnailUrl())
+                .category(blogPost.getCategory())
+                .isPrivate(blogPost.isPrivate())
+                .writerGrade(blogPost.getWriterGrade())
+                .writerName(blogPost.getWriterName())
+                .createdAt(blogPost.getCreatedAt())
+                .fileUrls(blogPost.getFiles().stream().map(BlogFile::getFileUrl).toList())
+                .imageUrls(blogPost.getImages().stream().map(BlogImage::getFileUrl).toList())
+                .build();
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/entity/BlogCategory.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/entity/BlogCategory.java
@@ -1,0 +1,7 @@
+package kr.dgucaps.caps.domain.blog.entity;
+
+public enum BlogCategory {
+    EVENTS,
+    ACADEMIC,
+    TECH
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/entity/BlogFile.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/entity/BlogFile.java
@@ -1,0 +1,33 @@
+package kr.dgucaps.caps.domain.blog.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "blog_file")
+public class BlogFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "blog_id", nullable = false)
+    private BlogPost blogPost;
+
+    @Column(name = "file_url", nullable = false, length = 512)
+    private String fileUrl;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    public BlogFile(BlogPost blogPost, String fileUrl, int sortOrder) {
+        this.blogPost = blogPost;
+        this.fileUrl = fileUrl;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/entity/BlogImage.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/entity/BlogImage.java
@@ -1,0 +1,33 @@
+package kr.dgucaps.caps.domain.blog.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "blog_image")
+public class BlogImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "blog_id", nullable = false)
+    private BlogPost blogPost;
+
+    @Column(name = "file_url", nullable = false, length = 512)
+    private String fileUrl;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    public BlogImage(BlogPost blogPost, String fileUrl, int sortOrder) {
+        this.blogPost = blogPost;
+        this.fileUrl = fileUrl;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/entity/BlogPost.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/entity/BlogPost.java
@@ -1,0 +1,134 @@
+package kr.dgucaps.caps.domain.blog.entity;
+
+import jakarta.persistence.*;
+import kr.dgucaps.caps.domain.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "blog_post")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlogPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(length = 100)
+    private String subtitle;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "thumbnail_url", length = 512)
+    private String thumbnailUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BlogCategory category;
+
+    @Column(name = "is_private", nullable = false)
+    private boolean isPrivate;
+
+    @Column(name = "writer_grade", nullable = false)
+    private Float writerGrade;
+
+    @Column(name = "writer_name", nullable = false, length = 50)
+    private String writerName;
+
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount = 0;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "blogPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
+    private List<BlogFile> files = new ArrayList<>();
+
+    @OneToMany(mappedBy = "blogPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
+    private List<BlogImage> images = new ArrayList<>();
+
+    @Builder
+    public BlogPost(
+            Member member,
+            String title,
+            String subtitle,
+            String content,
+            String thumbnailUrl,
+            BlogCategory category,
+            boolean isPrivate,
+            Float writerGrade,
+            String writerName
+    ) {
+        this.member = member;
+        this.title = title;
+        this.subtitle = subtitle;
+        this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+        this.category = category;
+        this.isPrivate = isPrivate;
+        this.writerGrade = writerGrade;
+        this.writerName = writerName;
+        this.viewCount = 0;
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    public void addFile(String fileUrl, int sortOrder) {
+        this.files.add(new BlogFile(this, fileUrl, sortOrder));
+    }
+
+    public void addImage(String fileUrl, int sortOrder) {
+        this.images.add(new BlogImage(this, fileUrl, sortOrder));
+    }
+
+    public void clearFiles() {
+        this.files.clear();
+    }
+
+    public void clearImages() {
+        this.images.clear();
+    }
+
+    public void update(
+            String title,
+            String subtitle,
+            String content,
+            String thumbnailUrl,
+            BlogCategory category,
+            boolean isPrivate,
+            Float writerGrade,
+            String writerName
+    ) {
+        this.title = title;
+        this.subtitle = subtitle;
+        this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+        this.category = category;
+        this.isPrivate = isPrivate;
+        this.writerGrade = writerGrade;
+        this.writerName = writerName;
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/integration/BlogS3FileDeleteListener.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/integration/BlogS3FileDeleteListener.java
@@ -1,0 +1,28 @@
+package kr.dgucaps.caps.domain.blog.integration;
+
+import kr.dgucaps.caps.domain.file.service.FileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BlogS3FileDeleteListener {
+
+    private final FileService fileService;
+
+    // 트랜잭션 커밋 후 S3 파일 삭제
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onBlogS3FilesDeleted(BlogS3FilesDeletedEvent event) {
+        for (String fileKey : event.fileKeys()) {
+            try {
+                fileService.deleteFile(fileKey);
+            } catch (Exception e) {
+                log.warn("S3 파일 삭제 실패 after commit. fileKey={}", fileKey, e);
+            }
+        }
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/integration/BlogS3FilesDeletedEvent.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/integration/BlogS3FilesDeletedEvent.java
@@ -1,0 +1,8 @@
+package kr.dgucaps.caps.domain.blog.integration;
+
+import java.util.List;
+
+public record BlogS3FilesDeletedEvent(
+        List<String> fileKeys
+) {
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogFileRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogFileRepository.java
@@ -1,0 +1,7 @@
+package kr.dgucaps.caps.domain.blog.repository;
+
+import kr.dgucaps.caps.domain.blog.entity.BlogFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogFileRepository extends JpaRepository<BlogFile, Integer> {
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogFileRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogFileRepository.java
@@ -4,4 +4,6 @@ import kr.dgucaps.caps.domain.blog.entity.BlogFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BlogFileRepository extends JpaRepository<BlogFile, Integer> {
+
+    boolean existsByFileUrl(String fileUrl);
 }

--- a/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogImageRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogImageRepository.java
@@ -1,0 +1,7 @@
+package kr.dgucaps.caps.domain.blog.repository;
+
+import kr.dgucaps.caps.domain.blog.entity.BlogImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogImageRepository extends JpaRepository<BlogImage, Integer> {
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogPostRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogPostRepository.java
@@ -1,0 +1,25 @@
+package kr.dgucaps.caps.domain.blog.repository;
+
+import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
+import kr.dgucaps.caps.domain.blog.entity.BlogPost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface BlogPostRepository extends JpaRepository<BlogPost, Integer> {
+
+    @EntityGraph(attributePaths = {"member"})
+    Page<BlogPost> findByCategoryAndIsPrivateFalse(BlogCategory category, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member"})
+    Page<BlogPost> findByCategory(BlogCategory category, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member", "files", "images"})
+    @Query("SELECT b FROM BlogPost b WHERE b.id = :id")
+    Optional<BlogPost> findWithDetailsById(@Param("id") Integer id);
+}

--- a/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogPostRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogPostRepository.java
@@ -19,6 +19,18 @@ public interface BlogPostRepository extends JpaRepository<BlogPost, Integer> {
     @EntityGraph(attributePaths = {"member"})
     Page<BlogPost> findByCategory(BlogCategory category, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"member"})
+    @Query("""
+            SELECT b FROM BlogPost b
+            WHERE b.category = :category
+              AND (b.isPrivate = false OR b.member.id = :memberId)
+            """)
+    Page<BlogPost> findVisibleByCategory(
+            @Param("category") BlogCategory category,
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
+
     @EntityGraph(attributePaths = {"member", "files", "images"})
     @Query("SELECT b FROM BlogPost b WHERE b.id = :id")
     Optional<BlogPost> findWithDetailsById(@Param("id") Integer id);

--- a/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogPostRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogPostRepository.java
@@ -31,7 +31,7 @@ public interface BlogPostRepository extends JpaRepository<BlogPost, Integer> {
             Pageable pageable
     );
 
-    @EntityGraph(attributePaths = {"member", "files", "images"})
+    @EntityGraph(attributePaths = {"member"})
     @Query("SELECT b FROM BlogPost b WHERE b.id = :id")
     Optional<BlogPost> findWithDetailsById(@Param("id") Integer id);
 }

--- a/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogPostRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogPostRepository.java
@@ -14,22 +14,13 @@ import java.util.Optional;
 public interface BlogPostRepository extends JpaRepository<BlogPost, Integer> {
 
     @EntityGraph(attributePaths = {"member"})
+    Page<BlogPost> findByIsPrivateFalse(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member"})
     Page<BlogPost> findByCategoryAndIsPrivateFalse(BlogCategory category, Pageable pageable);
 
     @EntityGraph(attributePaths = {"member"})
     Page<BlogPost> findByCategory(BlogCategory category, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"member"})
-    @Query("""
-            SELECT b FROM BlogPost b
-            WHERE b.category = :category
-              AND (b.isPrivate = false OR b.member.id = :memberId)
-            """)
-    Page<BlogPost> findVisibleByCategory(
-            @Param("category") BlogCategory category,
-            @Param("memberId") Long memberId,
-            Pageable pageable
-    );
 
     @EntityGraph(attributePaths = {"member"})
     @Query("SELECT b FROM BlogPost b WHERE b.id = :id")

--- a/src/main/java/kr/dgucaps/caps/domain/blog/service/BlogService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/service/BlogService.java
@@ -43,18 +43,18 @@ public class BlogService {
     private final ApplicationEventPublisher publisher;
 
     // 카테고리·권한별 게시물 목록 조회
-    public Page<BlogListResponse> getBlogsByPage(BlogCategory category, int page, Long memberId) {
+    public Page<BlogListResponse> getBlogsByPage(BlogCategory category, int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<BlogPost> blogPage = findBlogs(category, memberId, pageable);
+        Page<BlogPost> blogPage = findBlogs(category, pageable);
         return blogPage.map(BlogListResponse::from);
     }
 
     // 게시물 상세 조회 및 조회수 증가
     @Transactional
-    public BlogResponse getBlogById(Integer blogId, Long memberId) {
+    public BlogResponse getBlogById(Integer blogId) {
         BlogPost blogPost = blogPostRepository.findWithDetailsById(blogId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BLOG_NOT_FOUND));
-        validatePrivateAccess(blogPost, memberId);
+        validatePrivateAccess(blogPost);
         blogPost.increaseViewCount();
         return BlogResponse.from(blogPost);
     }
@@ -169,37 +169,36 @@ public class BlogService {
     }
 
     // 권한별 공개/비공개 범위 조회
-    private Page<BlogPost> findBlogs(BlogCategory category, Long memberId, Pageable pageable) {
-        if (canViewAllPrivatePosts()) {
+    private Page<BlogPost> findBlogs(BlogCategory category, Pageable pageable) {
+        if (hasBlogManageRole()) {
+            if (category == null) {
+                return blogPostRepository.findAll(pageable);
+            }
             return blogPostRepository.findByCategory(category, pageable);
         }
-        if (memberId != null) {
-            return blogPostRepository.findVisibleByCategory(category, memberId, pageable);
+        if (category == null) {
+            return blogPostRepository.findByIsPrivateFalse(pageable);
         }
         return blogPostRepository.findByCategoryAndIsPrivateFalse(category, pageable);
     }
 
     // 비공개 게시물 열람 권한 검사
-    private void validatePrivateAccess(BlogPost blogPost, Long memberId) {
+    private void validatePrivateAccess(BlogPost blogPost) {
         if (!blogPost.isPrivate()) {
             return;
         }
-        if (canViewAllPrivatePosts()) {
-            return;
+        if (!hasBlogManageRole()) {
+            throw new ForbiddenException(ErrorCode.BLOG_PRIVATE);
         }
-        if (memberId != null && blogPost.getMember().getId().equals(memberId)) {
-            return;
-        }
-        throw new ForbiddenException(ErrorCode.BLOG_PRIVATE);
     }
 
-    // 비공개 전체 열람 역할 검사
-    private boolean canViewAllPrivatePosts() {
+    // 블로그 관리 권한 (비공개 조회, 작성/수정/삭제)
+    private boolean hasBlogManageRole() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !(authentication.getPrincipal() instanceof CustomOAuth2User customUser)) {
             return false;
         }
         Role role = customUser.authDto().role();
-        return role == Role.PRESIDENT || role == Role.ADMIN;
+        return role == Role.COUNCIL || role == Role.PRESIDENT || role == Role.ADMIN;
     }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/blog/service/BlogService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/service/BlogService.java
@@ -1,12 +1,15 @@
 package kr.dgucaps.caps.domain.blog.service;
 
 import kr.dgucaps.caps.domain.auth.dto.CustomOAuth2User;
+import kr.dgucaps.caps.domain.blog.dto.request.CreateOrModifyBlogRequest;
 import kr.dgucaps.caps.domain.blog.dto.response.BlogListResponse;
 import kr.dgucaps.caps.domain.blog.dto.response.BlogResponse;
 import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
 import kr.dgucaps.caps.domain.blog.entity.BlogPost;
 import kr.dgucaps.caps.domain.blog.repository.BlogPostRepository;
+import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.domain.member.entity.Role;
+import kr.dgucaps.caps.domain.member.repository.MemberRepository;
 import kr.dgucaps.caps.global.error.ErrorCode;
 import kr.dgucaps.caps.global.error.exception.EntityNotFoundException;
 import kr.dgucaps.caps.global.error.exception.ForbiddenException;
@@ -20,6 +23,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -28,6 +33,7 @@ public class BlogService {
     private static final int PAGE_SIZE = 12;
 
     private final BlogPostRepository blogPostRepository;
+    private final MemberRepository memberRepository;
 
     // 카테고리·권한별 게시물 목록 조회
     public Page<BlogListResponse> getBlogsByPage(BlogCategory category, int page, Long memberId) {
@@ -44,6 +50,30 @@ public class BlogService {
         validatePrivateAccess(blogPost, memberId);
         blogPost.increaseViewCount();
         return BlogResponse.from(blogPost);
+    }
+
+    // 게시물 작성
+    @Transactional
+    public BlogResponse createBlog(Long memberId, CreateOrModifyBlogRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        BlogPost blogPost = request.toEntity(member);
+        attachFilesAndImages(blogPost, request.fileUrls(), request.imageUrls());
+        return BlogResponse.from(blogPostRepository.save(blogPost));
+    }
+
+    // 첨부파일·본문 이미지 연결
+    private void attachFilesAndImages(BlogPost blogPost, List<String> fileUrls, List<String> imageUrls) {
+        if (fileUrls != null) {
+            for (int i = 0; i < fileUrls.size(); i++) {
+                blogPost.addFile(fileUrls.get(i), i);
+            }
+        }
+        if (imageUrls != null) {
+            for (int i = 0; i < imageUrls.size(); i++) {
+                blogPost.addImage(imageUrls.get(i), i);
+            }
+        }
     }
 
     // 권한별 공개/비공개 범위 조회

--- a/src/main/java/kr/dgucaps/caps/domain/blog/service/BlogService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/service/BlogService.java
@@ -5,7 +5,10 @@ import kr.dgucaps.caps.domain.blog.dto.request.CreateOrModifyBlogRequest;
 import kr.dgucaps.caps.domain.blog.dto.response.BlogListResponse;
 import kr.dgucaps.caps.domain.blog.dto.response.BlogResponse;
 import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
+import kr.dgucaps.caps.domain.blog.entity.BlogFile;
+import kr.dgucaps.caps.domain.blog.entity.BlogImage;
 import kr.dgucaps.caps.domain.blog.entity.BlogPost;
+import kr.dgucaps.caps.domain.blog.integration.BlogS3FilesDeletedEvent;
 import kr.dgucaps.caps.domain.blog.repository.BlogPostRepository;
 import kr.dgucaps.caps.domain.member.entity.Member;
 import kr.dgucaps.caps.domain.member.entity.Role;
@@ -14,6 +17,7 @@ import kr.dgucaps.caps.global.error.ErrorCode;
 import kr.dgucaps.caps.global.error.exception.EntityNotFoundException;
 import kr.dgucaps.caps.global.error.exception.ForbiddenException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,7 +27,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @Transactional(readOnly = true)
@@ -34,6 +40,7 @@ public class BlogService {
 
     private final BlogPostRepository blogPostRepository;
     private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher publisher;
 
     // 카테고리·권한별 게시물 목록 조회
     public Page<BlogListResponse> getBlogsByPage(BlogCategory category, int page, Long memberId) {
@@ -58,22 +65,107 @@ public class BlogService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
         BlogPost blogPost = request.toEntity(member);
-        attachFilesAndImages(blogPost, request.fileUrls(), request.imageUrls());
+        attachFiles(blogPost, request.fileUrls());
+        attachImages(blogPost, request.imageUrls());
         return BlogResponse.from(blogPostRepository.save(blogPost));
     }
 
-    // 첨부파일·본문 이미지 연결
-    private void attachFilesAndImages(BlogPost blogPost, List<String> fileUrls, List<String> imageUrls) {
-        if (fileUrls != null) {
-            for (int i = 0; i < fileUrls.size(); i++) {
-                blogPost.addFile(fileUrls.get(i), i);
-            }
+    // 게시물 수정
+    @Transactional
+    public BlogResponse modifyBlog(Integer blogId, Long memberId, CreateOrModifyBlogRequest request) {
+        BlogPost blogPost = blogPostRepository.findWithDetailsById(blogId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BLOG_NOT_FOUND));
+
+        // 교체 전 URL 보관 (S3 정리 비교용)
+        List<String> oldFileUrls = blogPost.getFiles().stream().map(BlogFile::getFileUrl).toList();
+        List<String> oldImageUrls = blogPost.getImages().stream().map(BlogImage::getFileUrl).toList();
+        String oldThumbnailUrl = blogPost.getThumbnailUrl();
+
+        // 본문 필드 갱신
+        blogPost.update(
+                request.title(),
+                request.subtitle(),
+                request.content(),
+                request.thumbnailUrl(),
+                request.category(),
+                request.isPrivate(),
+                request.writerGrade(),
+                request.writerName()
+        );
+
+        List<String> urlsToDelete = new ArrayList<>();
+
+        // 첨부파일 전체 교체 (null이면 기존 유지)
+        if (request.fileUrls() != null) {
+            urlsToDelete.addAll(collectRemovedUrls(oldFileUrls, request.fileUrls()));
+            blogPost.clearFiles();
+            attachFiles(blogPost, request.fileUrls());
         }
-        if (imageUrls != null) {
-            for (int i = 0; i < imageUrls.size(); i++) {
-                blogPost.addImage(imageUrls.get(i), i);
-            }
+        // 본문 이미지 전체 교체 (null이면 기존 유지)
+        if (request.imageUrls() != null) {
+            urlsToDelete.addAll(collectRemovedUrls(oldImageUrls, request.imageUrls()));
+            blogPost.clearImages();
+            attachImages(blogPost, request.imageUrls());
         }
+        // 썸네일 교체 시 기존 URL 삭제
+        if (!Objects.equals(oldThumbnailUrl, request.thumbnailUrl()) && oldThumbnailUrl != null) {
+            urlsToDelete.add(oldThumbnailUrl);
+        }
+
+        publishS3DeleteEvent(urlsToDelete);
+        return BlogResponse.from(blogPost);
+    }
+
+    // 게시물 삭제
+    @Transactional
+    public void deleteBlog(Integer blogId) {
+        BlogPost blogPost = blogPostRepository.findWithDetailsById(blogId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BLOG_NOT_FOUND));
+
+        List<String> urlsToDelete = new ArrayList<>();
+        blogPost.getFiles().stream().map(BlogFile::getFileUrl).forEach(urlsToDelete::add);
+        blogPost.getImages().stream().map(BlogImage::getFileUrl).forEach(urlsToDelete::add);
+        if (blogPost.getThumbnailUrl() != null) {
+            urlsToDelete.add(blogPost.getThumbnailUrl());
+        }
+
+        blogPostRepository.delete(blogPost);
+        publishS3DeleteEvent(urlsToDelete);
+    }
+
+    // 첨부파일 연결
+    private void attachFiles(BlogPost blogPost, List<String> fileUrls) {
+        if (fileUrls == null) {
+            return;
+        }
+        for (int i = 0; i < fileUrls.size(); i++) {
+            blogPost.addFile(fileUrls.get(i), i);
+        }
+    }
+
+    // 본문 이미지 연결
+    private void attachImages(BlogPost blogPost, List<String> imageUrls) {
+        if (imageUrls == null) {
+            return;
+        }
+        for (int i = 0; i < imageUrls.size(); i++) {
+            blogPost.addImage(imageUrls.get(i), i);
+        }
+    }
+
+    // 제거된 URL 수집
+    private List<String> collectRemovedUrls(List<String> oldUrls, List<String> newUrls) {
+        return oldUrls.stream()
+                .filter(oldUrl -> !newUrls.contains(oldUrl))
+                .toList();
+    }
+
+    // S3 삭제 이벤트 발행
+    private void publishS3DeleteEvent(List<String> fileKeys) {
+        if (fileKeys.isEmpty()) {
+            return;
+        }
+        publisher.publishEvent(new BlogS3FilesDeletedEvent(fileKeys));
     }
 
     // 권한별 공개/비공개 범위 조회

--- a/src/main/java/kr/dgucaps/caps/domain/blog/service/BlogService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/service/BlogService.java
@@ -2,10 +2,14 @@ package kr.dgucaps.caps.domain.blog.service;
 
 import kr.dgucaps.caps.domain.auth.dto.CustomOAuth2User;
 import kr.dgucaps.caps.domain.blog.dto.response.BlogListResponse;
+import kr.dgucaps.caps.domain.blog.dto.response.BlogResponse;
 import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
 import kr.dgucaps.caps.domain.blog.entity.BlogPost;
 import kr.dgucaps.caps.domain.blog.repository.BlogPostRepository;
 import kr.dgucaps.caps.domain.member.entity.Role;
+import kr.dgucaps.caps.global.error.ErrorCode;
+import kr.dgucaps.caps.global.error.exception.EntityNotFoundException;
+import kr.dgucaps.caps.global.error.exception.ForbiddenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -25,14 +29,24 @@ public class BlogService {
 
     private final BlogPostRepository blogPostRepository;
 
-    // 카테고리·권한에 맞는 게시물 목록 페이지 반환
+    // 카테고리·권한별 게시물 목록 조회
     public Page<BlogListResponse> getBlogsByPage(BlogCategory category, int page, Long memberId) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<BlogPost> blogPage = findBlogs(category, memberId, pageable);
         return blogPage.map(BlogListResponse::from);
     }
 
-    // 권한에 따라 공개/비공개 포함 범위를 나눠 조회
+    // 게시물 상세 조회 및 조회수 증가
+    @Transactional
+    public BlogResponse getBlogById(Integer blogId, Long memberId) {
+        BlogPost blogPost = blogPostRepository.findWithDetailsById(blogId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BLOG_NOT_FOUND));
+        validatePrivateAccess(blogPost, memberId);
+        blogPost.increaseViewCount();
+        return BlogResponse.from(blogPost);
+    }
+
+    // 권한별 공개/비공개 범위 조회
     private Page<BlogPost> findBlogs(BlogCategory category, Long memberId, Pageable pageable) {
         if (canViewAllPrivatePosts()) {
             return blogPostRepository.findByCategory(category, pageable);
@@ -43,7 +57,21 @@ public class BlogService {
         return blogPostRepository.findByCategoryAndIsPrivateFalse(category, pageable);
     }
 
-    // 현재 사용자가 모든 비공개 게시물을 볼 수 있는 역할인지 확인
+    // 비공개 게시물 열람 권한 검사
+    private void validatePrivateAccess(BlogPost blogPost, Long memberId) {
+        if (!blogPost.isPrivate()) {
+            return;
+        }
+        if (canViewAllPrivatePosts()) {
+            return;
+        }
+        if (memberId != null && blogPost.getMember().getId().equals(memberId)) {
+            return;
+        }
+        throw new ForbiddenException(ErrorCode.BLOG_PRIVATE);
+    }
+
+    // 비공개 전체 열람 역할 검사
     private boolean canViewAllPrivatePosts() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !(authentication.getPrincipal() instanceof CustomOAuth2User customUser)) {

--- a/src/main/java/kr/dgucaps/caps/domain/blog/service/BlogService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/service/BlogService.java
@@ -1,0 +1,55 @@
+package kr.dgucaps.caps.domain.blog.service;
+
+import kr.dgucaps.caps.domain.auth.dto.CustomOAuth2User;
+import kr.dgucaps.caps.domain.blog.dto.response.BlogListResponse;
+import kr.dgucaps.caps.domain.blog.entity.BlogCategory;
+import kr.dgucaps.caps.domain.blog.entity.BlogPost;
+import kr.dgucaps.caps.domain.blog.repository.BlogPostRepository;
+import kr.dgucaps.caps.domain.member.entity.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BlogService {
+
+    private static final int PAGE_SIZE = 12;
+
+    private final BlogPostRepository blogPostRepository;
+
+    // 카테고리·권한에 맞는 게시물 목록 페이지 반환
+    public Page<BlogListResponse> getBlogsByPage(BlogCategory category, int page, Long memberId) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<BlogPost> blogPage = findBlogs(category, memberId, pageable);
+        return blogPage.map(BlogListResponse::from);
+    }
+
+    // 권한에 따라 공개/비공개 포함 범위를 나눠 조회
+    private Page<BlogPost> findBlogs(BlogCategory category, Long memberId, Pageable pageable) {
+        if (canViewAllPrivatePosts()) {
+            return blogPostRepository.findByCategory(category, pageable);
+        }
+        if (memberId != null) {
+            return blogPostRepository.findVisibleByCategory(category, memberId, pageable);
+        }
+        return blogPostRepository.findByCategoryAndIsPrivateFalse(category, pageable);
+    }
+
+    // 현재 사용자가 모든 비공개 게시물을 볼 수 있는 역할인지 확인
+    private boolean canViewAllPrivatePosts() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomOAuth2User customUser)) {
+            return false;
+        }
+        Role role = customUser.authDto().role();
+        return role == Role.PRESIDENT || role == Role.ADMIN;
+    }
+}

--- a/src/main/java/kr/dgucaps/caps/domain/file/controller/FileController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/file/controller/FileController.java
@@ -2,9 +2,12 @@ package kr.dgucaps.caps.domain.file.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import kr.dgucaps.caps.domain.blog.repository.BlogFileRepository;
 import kr.dgucaps.caps.domain.file.dto.request.PresignedUrlRequest;
 import kr.dgucaps.caps.domain.file.service.FileService;
 import kr.dgucaps.caps.global.common.SuccessResponse;
+import kr.dgucaps.caps.global.error.ErrorCode;
+import kr.dgucaps.caps.global.error.exception.ForbiddenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -20,6 +23,7 @@ import java.util.Map;
 public class FileController {
 
     private final FileService fileService;
+    private final BlogFileRepository blogFileRepository;
 
     // Presigned URL 발급 (파일 업로드용)
     @PreAuthorize("hasAnyRole('MEMBER', 'GRADUATE', 'COUNCIL', 'PRESIDENT', 'ADMIN')")
@@ -33,11 +37,22 @@ public class FileController {
         return SuccessResponse.ok(result);
     }
 
-    // Presigned URL 발급 (다운로드용)
+    // Presigned URL 발급 (다운로드용) — ledger, Report: MEMBER 이상
     @PreAuthorize("hasAnyRole('MEMBER', 'GRADUATE', 'COUNCIL', 'PRESIDENT', 'ADMIN')")
     @GetMapping("/presigned-url")
     public ResponseEntity<SuccessResponse<?>> getPresignedDownloadUrl(
             @RequestParam("key") @NotBlank String fileKey) {
+        String presignedUrl = fileService.generatePresignedDownloadUrl(fileKey);
+        return SuccessResponse.ok(Map.of("downloadURL", presignedUrl));
+    }
+
+    // 블로그 첨부파일 다운로드 — (비로그인 포함) 공개
+    @GetMapping("/blog/presigned-url")
+    public ResponseEntity<SuccessResponse<?>> getBlogPresignedDownloadUrl(
+            @RequestParam("key") @NotBlank String fileKey) {
+        if (!blogFileRepository.existsByFileUrl(fileKey)) {
+            throw new ForbiddenException(ErrorCode.FORBIDDEN);
+        }
         String presignedUrl = fileService.generatePresignedDownloadUrl(fileKey);
         return SuccessResponse.ok(Map.of("downloadURL", presignedUrl));
     }
@@ -51,4 +66,3 @@ public class FileController {
         return SuccessResponse.noContent();
     }
 }
-

--- a/src/main/java/kr/dgucaps/caps/global/config/auth/SecurityConfig.java
+++ b/src/main/java/kr/dgucaps/caps/global/config/auth/SecurityConfig.java
@@ -6,6 +6,7 @@ import kr.dgucaps.caps.global.config.auth.jwt.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -66,6 +67,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                         authorizationManagerRequestMatcherRegistry
                                 .requestMatchers(whiteList).permitAll()
+                                // JWT는 통과시키되 비로그인도 허용 (비공개글 권한 판별용)
+                                .requestMatchers(HttpMethod.GET, "/api/v1/blogs", "/api/v1/blogs/*").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/files/blog/presigned-url").permitAll()
                                 .requestMatchers("/api/v1/auth/complete-registration").hasRole("CONSENT")
                                 .requestMatchers("/api/**").hasRole("ACCESS")
                                 .anyRequest().authenticated()

--- a/src/main/java/kr/dgucaps/caps/global/error/ErrorCode.java
+++ b/src/main/java/kr/dgucaps/caps/global/error/ErrorCode.java
@@ -45,7 +45,11 @@ public enum ErrorCode {
     WIKI_ALREADY_EXISTS(HttpStatus.CONFLICT, "W002", "이미 존재하는 위키입니다."),
 
     // Ledger
-    LEDGER_NOT_FOUND(HttpStatus.NOT_FOUND, "L001", "장부가 존재하지 않습니다.")
+    LEDGER_NOT_FOUND(HttpStatus.NOT_FOUND, "L001", "장부가 존재하지 않습니다."),
+
+    // Blog
+    BLOG_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "블로그 게시물이 존재하지 않습니다."),
+    BLOG_PRIVATE(HttpStatus.FORBIDDEN, "B002", "비공개 처리된 게시물입니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #66 
## 📝 작업 내용

## Summary
- 블로그 게시물 CRUD API 및 도메인(Entity, Repository, Service, Controller) 추가
- 비로그인 사용자의 목록·상세 조회 및 블로그 첨부파일 공개 다운로드 지원
- 수정·삭제 시 S3 파일 정리를 DB 커밋 이후 이벤트로 분리
- BlogServiceTest, BlogS3FileDeleteListenerTest 등 단위 테스트 17건 추가 및 전체 통과

## 구현 내용
### API

Method | Endpoint | 설명
-- | -- | --
GET | /api/v1/blogs?category=&page= | 게시물 목록 (페이지당 12개, createdAt 내림차순)
GET | /api/v1/blogs/{blogId} | 게시물 상세
POST | /api/v1/blogs | 게시물 작성
PUT | /api/v1/blogs/{blogId} | 게시물 수정
DELETE | /api/v1/blogs/{blogId} | 게시물 삭제
GET | /api/v1/files/blog/presigned-url | 블로그 첨부파일 다운로드 (비로그인 허용)

### 주요 동작
- 목록·상세 조회 시 viewCount는 내부적으로만 증가·관리하고 API 응답에는 포함하지 않음
- 목록 응답에 isPrivate 포함 (비공개 게시물)
- 본문은 마크다운 원문으로 저장, HTML 렌더링은 프론트엔드에서 담당
- 기존 파일 도메인 API(presigned-url 업로드/삭제) 재사용

## 테스트
- BlogServiceTest (14건)
  - 목록 조회: 비로그인(전체/카테고리별 공개만), 관리 권한(전체/카테고리별 공개+비공개)
  - 상세 조회: 공개 글 조회수 증가, 비공개 글 접근 차단/허용, 존재하지 않는 게시물 404
  - 작성: 정상 작성, 존재하지 않는 회원 404
  - 수정: 제거된 파일 S3 삭제 이벤트 발행, fileUrls null 시 기존 첨부 유지
  - 삭제: 연결된 파일 S3 삭제 이벤트 발행, 존재하지 않는 게시물 404
- BlogS3FileDeleteListenerTest (2건)
  - 커밋 후 S3 파일 삭제 처리
  - 개별 파일 삭제 실패 시 나머지 파일 계속 삭제
- CapsApplicationTests (1건)
  - test 프로필(H2) 기반 Spring 컨텍스트 로드

- 실행 결과: 17/17 통과

## 📢 참고 사항

### 권한 범위

구분 | 비로그인 | 일반 사용자 | COUNCIL / PRESIDENT / ADMIN
-- | -- | -- | --
목록·상세 조회 (공개 글) | ✅ | ✅ | ✅
목록·상세 조회 (비공개 글) | ❌ | ❌ | ✅
작성·수정·삭제 | ❌ | ❌ | ✅
블로그 첨부파일 다운로드 | ✅ | ✅ | ✅

- 비공개 글 조회는 작성자 여부와 무관하게 COUNCIL, PRESIDENT, ADMIN만 가능
- 작성·수정·삭제도 동일 role로 제한 (작성자 본인 여부는 검사하지 않음)

### 카테고리
- 카테고리 미지정 시: 일반 사용자는 공개 글 전체, 관리 권한 사용자는 공개+비공개 전체
- 수정·삭제 시 파일/이미지 처리

### 게시물 수정

- fileUrls / imageUrls가 null이면 해당 항목은 기존 유지
- 값이 있으면 기존 목록을 전부 교체하고, 요청 배열 순서대로 sortOrder 재계산
- 새 목록에 없는 기존 URL + 교체된 썸네일 URL은 S3 삭제 대상으로 수집
- S3 삭제는 DB 반영이 완료된 뒤(AFTER_COMMIT) 이벤트로 처리 → 트랜잭션 롤백 시 S3 파일이 먼저 삭제되는 문제 방지
삭제
- 게시물 하드 삭제 (blog_file, blog_image는 cascade로 함께 삭제)
- 연결된 첨부파일·본문 이미지·썸네일 URL 전부 S3 삭제 대상으로 수집 후, DB 커밋 이후 이벤트로 S3 정리

