### PR TITLE
Develop

### DIFF
--- a/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/controller/BlogController.java
@@ -74,6 +74,6 @@ public class BlogController implements BlogApi {
             @PathVariable("blogId") Integer blogId
     ) {
         blogService.deleteBlog(blogId);
-        return ResponseEntity.noContent().build();
+        return SuccessResponse.noContent();
     }
 }

--- a/src/main/java/kr/dgucaps/caps/domain/ledger/controller/LedgerController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/ledger/controller/LedgerController.java
@@ -59,7 +59,7 @@ public class LedgerController implements LedgerApi {
             @PathVariable("ledgerId") Long ledgerId
     ) {
         ledgerService.deleteLedger(ledgerId, memberId);
-        return ResponseEntity.noContent().build();
+        return SuccessResponse.noContent();
     }
 
 }

--- a/src/main/java/kr/dgucaps/caps/global/common/SuccessCode.java
+++ b/src/main/java/kr/dgucaps/caps/global/common/SuccessCode.java
@@ -17,12 +17,7 @@ public enum SuccessCode {
     /**
      * 201 Created
      */
-    CREATED(HttpStatus.CREATED, "요청이 성공했습니다."),
-
-    /**
-     * 204 No Content
-     */
-    NO_CONTENT(HttpStatus.NO_CONTENT, "요청이 성공했습니다.");
+    CREATED(HttpStatus.CREATED, "요청이 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/kr/dgucaps/caps/global/common/SuccessResponse.java
+++ b/src/main/java/kr/dgucaps/caps/global/common/SuccessResponse.java
@@ -26,7 +26,7 @@ public class SuccessResponse<T> {
                 .body(SuccessResponse.of(SuccessCode.CREATED, data));
     }
 
-    public static ResponseEntity<SuccessResponse<?>> noContent() {
+    public static ResponseEntity<Void> noContent() {
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/kr/dgucaps/caps/global/common/SuccessResponse.java
+++ b/src/main/java/kr/dgucaps/caps/global/common/SuccessResponse.java
@@ -27,8 +27,7 @@ public class SuccessResponse<T> {
     }
 
     public static ResponseEntity<SuccessResponse<?>> noContent() {
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .body(SuccessResponse.of(SuccessCode.NO_CONTENT, null));
+        return ResponseEntity.noContent().build();
     }
 
     public static <T> SuccessResponse<?> of(SuccessCode successCode, T data) {


### PR DESCRIPTION
### 작업 내용
- HTTP 204 응답에서 body를 제거해 표준에 맞게 수정
- SuccessResponse.noContent()를 본문 없는 ResponseEntity.noContent()로 변경
- 사용처(블로그/장부 삭제 등)를 SuccessResponse.noContent()로 통일
- 더 이상 쓰이지 않는 SuccessCode.NO_CONTENT 제거

### 변경 이유
- 204 No Content는 응답 본문이 없어야 하는데, 기존 SuccessResponse.noContent()는 status 204와 함께 message/data body를 내려주고 있었습니다.