### PR TITLE
fix: 블로그 이미지·썸네일도 비로그인 조회 허용

### DIFF
--- a/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogImageRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogImageRepository.java
@@ -4,4 +4,6 @@ import kr.dgucaps.caps.domain.blog.entity.BlogImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BlogImageRepository extends JpaRepository<BlogImage, Integer> {
+
+    boolean existsByFileUrl(String fileUrl);
 }

--- a/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogPostRepository.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/repository/BlogPostRepository.java
@@ -25,4 +25,6 @@ public interface BlogPostRepository extends JpaRepository<BlogPost, Integer> {
     @EntityGraph(attributePaths = {"member"})
     @Query("SELECT b FROM BlogPost b WHERE b.id = :id")
     Optional<BlogPost> findWithDetailsById(@Param("id") Integer id);
+
+    boolean existsByThumbnailUrl(String thumbnailUrl);
 }

--- a/src/main/java/kr/dgucaps/caps/domain/file/controller/FileController.java
+++ b/src/main/java/kr/dgucaps/caps/domain/file/controller/FileController.java
@@ -3,6 +3,8 @@ package kr.dgucaps.caps.domain.file.controller;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import kr.dgucaps.caps.domain.blog.repository.BlogFileRepository;
+import kr.dgucaps.caps.domain.blog.repository.BlogImageRepository;
+import kr.dgucaps.caps.domain.blog.repository.BlogPostRepository;
 import kr.dgucaps.caps.domain.file.dto.request.PresignedUrlRequest;
 import kr.dgucaps.caps.domain.file.service.FileService;
 import kr.dgucaps.caps.global.common.SuccessResponse;
@@ -24,6 +26,8 @@ public class FileController {
 
     private final FileService fileService;
     private final BlogFileRepository blogFileRepository;
+    private final BlogImageRepository blogImageRepository;
+    private final BlogPostRepository blogPostRepository;
 
     // Presigned URL 발급 (파일 업로드용)
     @PreAuthorize("hasAnyRole('MEMBER', 'GRADUATE', 'COUNCIL', 'PRESIDENT', 'ADMIN')")
@@ -46,11 +50,11 @@ public class FileController {
         return SuccessResponse.ok(Map.of("downloadURL", presignedUrl));
     }
 
-    // 블로그 첨부파일 다운로드 — (비로그인 포함) 공개
+    // 블로그 첨부파일·본문 이미지·썸네일 조회/다운로드 — (비로그인 포함) 공개
     @GetMapping("/blog/presigned-url")
     public ResponseEntity<SuccessResponse<?>> getBlogPresignedDownloadUrl(
             @RequestParam("key") @NotBlank String fileKey) {
-        if (!blogFileRepository.existsByFileUrl(fileKey)) {
+        if (!isBlogAsset(fileKey)) {
             throw new ForbiddenException(ErrorCode.FORBIDDEN);
         }
         String presignedUrl = fileService.generatePresignedDownloadUrl(fileKey);
@@ -64,5 +68,12 @@ public class FileController {
             @RequestParam("key") @NotBlank String fileKey) {
         fileService.deleteFile(fileKey);
         return SuccessResponse.noContent();
+    }
+
+    // 블로그에 등록된 첨부파일·본문 이미지·썸네일인지 확인
+    private boolean isBlogAsset(String fileKey) {
+        return blogFileRepository.existsByFileUrl(fileKey)
+                || blogImageRepository.existsByFileUrl(fileKey)
+                || blogPostRepository.existsByThumbnailUrl(fileKey);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #66 

## 요약
- 블로그 공개 다운로드 API에서 본문 이미지·썸네일도 허용
- 비로그인 사용자가 공개 글의 텍스트뿐 아니라 이미지·첨부파일까지 볼 수 있도록 수정

## 변경 내용
- GET /api/v1/files/blog/presigned-url?key={fileKey} 허용 대상 확장

대상 | 변경 전 | 변경 후
-- | -- | --
첨부파일 (blog_file) | ✅ | ✅
본문 이미지 (blog_image) | ❌ | ✅
썸네일 (thumbnail_url) | ❌ | ✅

- Security permitAll은 기존과 동일
- ledger 등 다른 도메인 파일은 기존처럼 MEMBER 이상만 다운로드 가능