### PR TITLE
feat: 블로그 상세 응답에 thumbnailUrl 추가

### DIFF
--- a/src/main/java/kr/dgucaps/caps/domain/blog/dto/response/BlogDetailResponse.java
+++ b/src/main/java/kr/dgucaps/caps/domain/blog/dto/response/BlogDetailResponse.java
@@ -15,6 +15,7 @@ public record BlogDetailResponse(
         String title,
         String subtitle,
         String content,
+        String thumbnailUrl,
         BlogCategory category,
         boolean isPrivate,
         Float writerGrade,
@@ -29,6 +30,7 @@ public record BlogDetailResponse(
                 .title(blogPost.getTitle())
                 .subtitle(blogPost.getSubtitle())
                 .content(blogPost.getContent())
+                .thumbnailUrl(blogPost.getThumbnailUrl())
                 .category(blogPost.getCategory())
                 .isPrivate(blogPost.isPrivate())
                 .writerGrade(blogPost.getWriterGrade())


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 

## 📝 작업 내용
- `BlogDetailResponse`에 `thumbnailUrl` 필드 추가 (`BlogPost.getThumbnailUrl()` 매핑)

## 📢 참고 사항
- 프론트 블로그 **수정 화면**에서 기존 대표 이미지를 표시하려면 상세 응답에 `thumbnailUrl`이 필요합니다. 현재는 이 값이 없어, 수정 시 대표 이미지를 새로 고르지 않으면 썸네일이 누락되는 문제가 있습니다(프론트가 기존 값을 알 수 없어 PATCH에서 생략 → null 처리됨).
- 이 필드가 추가되면 프론트에서 기존 썸네일을 프리필하고 수정 시 그대로 보존할 수 있습니다.
- 응답 필드만 추가하는 변경이라 기존 동작에 영향 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)