### PR TITLE
fix: S3Presigner에 region 명시 및 JVM UTF-8 인코딩 고정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ ARG JAR_FILE=build/libs/caps-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
 
 # JVM 시간대 설정을 포함한 애플리케이션 실행
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-Dfile.encoding=UTF-8", "-Dsun.jnu.encoding=UTF-8", "-Duser.timezone=Asia/Seoul", "-jar", "/app.jar"]

--- a/src/main/java/kr/dgucaps/caps/domain/file/service/FileService.java
+++ b/src/main/java/kr/dgucaps/caps/domain/file/service/FileService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -44,7 +45,7 @@ public class FileService {
                     .contentType(fileType != null ? fileType : "application/octet-stream")
                     .build();
 
-            try (S3Presigner presigner = S3Presigner.create()) {
+            try (S3Presigner presigner = S3Presigner.builder().region(Region.of(region)).build()) {
                 PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
                         .signatureDuration(Duration.ofMinutes(5)) // 5분 유효
                         .putObjectRequest(putObjectRequest)
@@ -77,7 +78,7 @@ public class FileService {
                     .key(fileKey)
                     .build();
 
-            try (S3Presigner presigner = S3Presigner.create()) {
+            try (S3Presigner presigner = S3Presigner.builder().region(Region.of(region)).build()) {
                 GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
                         .signatureDuration(Duration.ofMinutes(15)) // 15분 유효
                         .getObjectRequest(getObjectRequest)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #66 

## Summary
- `S3Presigner`가 AWS 기본 region 체인에 의존하지 않도록 `aws.s3.region`을 명시한다. (`AWS_S3_REGION`만 있고 `AWS_REGION`이 없는 배포 환경 대응)
- Alpine JDK 17 컨테이너에서 JVM 기본 문자셋이 UTF-8이 아닐 수 있어 `-Dfile.encoding=UTF-8`, `-Dsun.jnu.encoding=UTF-8`을 고정한다.
- 한글이 포함된 S3 key로 블로그 이미지 presigned 조회가 403으로 실패하는 문제를 완화한다.